### PR TITLE
Fix #35: don't trigger peek during desktop drag-select

### DIFF
--- a/src/PeekDesktop/MouseHook.cs
+++ b/src/PeekDesktop/MouseHook.cs
@@ -22,6 +22,12 @@ public sealed class MouseHook : IDisposable
     private long _lastClickTick;
     private NativeMethods.POINT _lastClickPoint;
 
+    // Pending-click state: we defer firing the classification event until WM_LBUTTONUP
+    // so we can suppress the peek when the user is actually drag-selecting icons
+    // on the desktop (e.g. marquee multi-select). See issue #35.
+    private bool _hasPendingClick;
+    private NativeMethods.POINT _pendingDownPoint;
+
     /// <summary>
     /// When true, only double-clicks trigger desktop peek (single clicks are ignored).
     /// </summary>
@@ -74,44 +80,95 @@ public sealed class MouseHook : IDisposable
     /// </summary>
     private unsafe IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
     {
-        if (nCode >= 0 && wParam == (IntPtr)NativeMethods.WM_LBUTTONDOWN)
+        if (nCode >= 0)
         {
-            var hookStruct = *(NativeMethods.MSLLHOOKSTRUCT*)lParam;
-            var clickPoint = hookStruct.pt;
+            int message = wParam.ToInt32();
 
-            if (RequireDoubleClick)
+            if (message == NativeMethods.WM_LBUTTONDOWN)
             {
-                long now = Environment.TickCount64;
-                uint doubleClickTime = NativeMethods.GetDoubleClickTime();
-                int cxThreshold = NativeMethods.GetSystemMetrics(NativeMethods.SM_CXDOUBLECLK) / 2;
-                int cyThreshold = NativeMethods.GetSystemMetrics(NativeMethods.SM_CYDOUBLECLK) / 2;
+                var hookStruct = *(NativeMethods.MSLLHOOKSTRUCT*)lParam;
+                var clickPoint = hookStruct.pt;
 
-                bool withinTime = (now - _lastClickTick) <= doubleClickTime;
-                bool withinDistance = Math.Abs(clickPoint.x - _lastClickPoint.x) <= cxThreshold
-                                  && Math.Abs(clickPoint.y - _lastClickPoint.y) <= cyThreshold;
-
-                _lastClickTick = now;
-                _lastClickPoint = clickPoint;
-
-                if (!(withinTime && withinDistance))
+                if (RequireDoubleClick)
                 {
-                    // First click of a potential double-click — swallow it
-                    return NativeMethods.CallNextHookEx(_hookId, nCode, wParam, lParam);
+                    long now = Environment.TickCount64;
+                    uint doubleClickTime = NativeMethods.GetDoubleClickTime();
+                    int cxThreshold = NativeMethods.GetSystemMetrics(NativeMethods.SM_CXDOUBLECLK) / 2;
+                    int cyThreshold = NativeMethods.GetSystemMetrics(NativeMethods.SM_CYDOUBLECLK) / 2;
+
+                    bool withinTime = (now - _lastClickTick) <= doubleClickTime;
+                    bool withinDistance = Math.Abs(clickPoint.x - _lastClickPoint.x) <= cxThreshold
+                                      && Math.Abs(clickPoint.y - _lastClickPoint.y) <= cyThreshold;
+
+                    _lastClickTick = now;
+                    _lastClickPoint = clickPoint;
+
+                    if (!(withinTime && withinDistance))
+                    {
+                        // First click of a potential double-click — don't arm the pending trigger yet
+                        _hasPendingClick = false;
+                        return NativeMethods.CallNextHookEx(_hookId, nCode, wParam, lParam);
+                    }
+
+                    // Reset so a third click doesn't also fire
+                    _lastClickTick = 0;
                 }
 
-                // Reset so a third click doesn't also fire
-                _lastClickTick = 0;
+                // Arm a pending click; the actual classification + event will fire
+                // on WM_LBUTTONUP, unless the user drags beyond the drag threshold
+                // (which indicates a marquee / drag-select gesture).
+                _hasPendingClick = true;
+                _pendingDownPoint = clickPoint;
             }
+            else if (message == NativeMethods.WM_MOUSEMOVE)
+            {
+                if (_hasPendingClick)
+                {
+                    var hookStruct = *(NativeMethods.MSLLHOOKSTRUCT*)lParam;
+                    if (HasExceededDragThreshold(_pendingDownPoint, hookStruct.pt))
+                    {
+                        _hasPendingClick = false;
+                        AppDiagnostics.Log("Pending peek click cancelled (drag detected)");
+                    }
+                }
+            }
+            else if (message == NativeMethods.WM_LBUTTONUP)
+            {
+                if (_hasPendingClick)
+                {
+                    _hasPendingClick = false;
+                    var hookStruct = *(NativeMethods.MSLLHOOKSTRUCT*)lParam;
+                    var upPoint = hookStruct.pt;
 
-            IntPtr windowUnderCursor = NativeMethods.WindowFromPoint(clickPoint);
+                    if (HasExceededDragThreshold(_pendingDownPoint, upPoint))
+                    {
+                        AppDiagnostics.Log("Pending peek click cancelled on mouse-up (drag detected)");
+                    }
+                    else
+                    {
+                        // Classify based on the original press location so a tiny
+                        // cursor jitter during the click doesn't change the target.
+                        var classifyPoint = _pendingDownPoint;
+                        IntPtr windowUnderCursor = NativeMethods.WindowFromPoint(classifyPoint);
 
-            if (_syncContext is not null)
-                _syncContext.Post(_ => HandleMouseClick(windowUnderCursor, clickPoint), null);
-            else
-                HandleMouseClick(windowUnderCursor, clickPoint);
+                        if (_syncContext is not null)
+                            _syncContext.Post(_ => HandleMouseClick(windowUnderCursor, classifyPoint), null);
+                        else
+                            HandleMouseClick(windowUnderCursor, classifyPoint);
+                    }
+                }
+            }
         }
 
         return NativeMethods.CallNextHookEx(_hookId, nCode, wParam, lParam);
+    }
+
+    private static bool HasExceededDragThreshold(NativeMethods.POINT from, NativeMethods.POINT to)
+    {
+        int cxDrag = NativeMethods.GetSystemMetrics(NativeMethods.SM_CXDRAG);
+        int cyDrag = NativeMethods.GetSystemMetrics(NativeMethods.SM_CYDRAG);
+        return Math.Abs(to.x - from.x) > cxDrag
+            || Math.Abs(to.y - from.y) > cyDrag;
     }
 
     private void HandleMouseClick(IntPtr windowUnderCursor, NativeMethods.POINT clickPoint)

--- a/src/PeekDesktop/NativeMethods.cs
+++ b/src/PeekDesktop/NativeMethods.cs
@@ -15,7 +15,9 @@ internal static class NativeMethods
     public const int WH_MOUSE_LL = 14;
 
     // --- Mouse messages ---
+    public const int WM_MOUSEMOVE = 0x0200;
     public const int WM_LBUTTONDOWN = 0x0201;
+    public const int WM_LBUTTONUP = 0x0202;
 
     // --- ShowWindow commands ---
     public const int SW_SHOWNORMAL = 1;
@@ -282,6 +284,8 @@ internal static class NativeMethods
 
     public const int SM_CXDOUBLECLK = 36;
     public const int SM_CYDOUBLECLK = 37;
+    public const int SM_CXDRAG = 68;
+    public const int SM_CYDRAG = 69;
 
     // --- Monitor info ---
     public const uint MONITOR_DEFAULTTONEAREST = 2;


### PR DESCRIPTION
Fixes #35.

## Problem
Starting a marquee (drag-select) gesture on the desktop to multi-select icons currently triggers peek, because peek fires on `WM_LBUTTONDOWN`.

## Fix
Defer the peek trigger from `WM_LBUTTONDOWN` to `WM_LBUTTONUP`, and cancel the pending trigger if the cursor moves beyond the system drag threshold (`SM_CXDRAG` / `SM_CYDRAG`) between press and release. This matches the approach suggested in the issue.

### Details
- `MouseHook.cs`: added pending-click state (`_hasPendingClick` + `_pendingDownPoint`). `WM_LBUTTONDOWN` now arms the pending click; `WM_MOUSEMOVE` cancels it once the drag threshold is exceeded; `WM_LBUTTONUP` fires the classification + event if no drag was detected.
- Classification uses the original press point so tiny cursor jitter during a click doesn't change the click target.
- Double-click mode is preserved: the first click no longer arms a pending trigger, and the second click's release fires the event (still cancelled if it turns into a drag).
- `NativeMethods.cs`: added `WM_LBUTTONUP`, `WM_MOUSEMOVE`, `SM_CXDRAG`, `SM_CYDRAG` constants.

## Testing
- Built with `dotnet publish -c Release -r win-x64` (NativeAOT) — no warnings/errors.
- Manually verified on Windows:
  - Marquee drag on empty desktop no longer triggers peek.
  - Normal click on empty desktop still triggers peek on release.
  - Click on a desktop icon: no peek (unchanged).
  - Click on a window while peeking: exits peek (unchanged).