### PR TITLE
Left-click tray icon toggles peek

### DIFF
--- a/src/PeekDesktop/DesktopPeek.cs
+++ b/src/PeekDesktop/DesktopPeek.cs
@@ -43,6 +43,12 @@ public sealed class DesktopPeek : IDisposable
     public bool IsPeeking => _isPeeking;
     public PeekMode PeekMode { get; set; }
 
+    /// <summary>
+    /// Toggles peek state as if the user had clicked the desktop wallpaper.
+    /// Honors the same enabled / transition / gaming guards as a real desktop click.
+    /// </summary>
+    public void TogglePeek() => OnDesktopClicked(this, EventArgs.Empty);
+
     public DesktopPeek(Settings settings)
     {
         PeekMode = NormalizePeekMode(settings.PeekMode);

--- a/src/PeekDesktop/TrayIcon.cs
+++ b/src/PeekDesktop/TrayIcon.cs
@@ -81,6 +81,13 @@ internal sealed class TrayIcon : IDisposable
                 return (true, IntPtr.Zero);
             }
 
+            if (Win32TrayIcon.IsLeftClick(lParam))
+            {
+                AppDiagnostics.Log("Tray icon left-clicked; toggling peek");
+                _desktopPeek.TogglePeek();
+                return (true, IntPtr.Zero);
+            }
+
             if (Win32TrayIcon.IsBalloonClick(lParam))
             {
                 _appUpdater.OpenLatestReleasePage();

--- a/src/PeekDesktop/Win32TrayIcon.cs
+++ b/src/PeekDesktop/Win32TrayIcon.cs
@@ -106,6 +106,16 @@ internal sealed class Win32TrayIcon : IDisposable
         LOWORD(lParam) == WM_RBUTTONUP || LOWORD(lParam) == WM_CONTEXTMENU;
 
     /// <summary>
+    /// Returns true if lParam represents a left-click (mouse select or keyboard
+    /// activation) on the tray icon. Requires NOTIFYICON_VERSION_4 behavior.
+    /// </summary>
+    public static bool IsLeftClick(IntPtr lParam)
+    {
+        ushort code = LOWORD(lParam);
+        return code == NIN_SELECT || code == NIN_KEYSELECT;
+    }
+
+    /// <summary>
     /// Returns true if lParam represents a left double-click on the tray icon.
     /// </summary>
     public static bool IsLeftDoubleClick(IntPtr lParam) =>
@@ -143,6 +153,8 @@ internal sealed class Win32TrayIcon : IDisposable
     private const ushort WM_RBUTTONUP = 0x0205;
     private const ushort WM_LBUTTONDBLCLK = 0x0203;
     private const ushort WM_CONTEXTMENU = 0x007B;
+    private const ushort NIN_SELECT = 0x0400;
+    private const ushort NIN_KEYSELECT = 0x0401;
     private const ushort NIN_BALLOONUSERCLICK = 0x0405;
 
     // --- Struct ---


### PR DESCRIPTION
Fixes https://github.com/shanselman/PeekDesktop/issues/37

## What
Left-click (or keyboard activation) on the PeekDesktop tray icon now toggles peek — the same behavior as clicking the desktop wallpaper. Right-click still opens the context menu.

## Why
Users expect a one-click toggle from the notification area; previously only the desktop click or the context menu could control peek state.

## How
- `DesktopPeek.TogglePeek()`: new public method that routes through the existing `OnDesktopClicked` handler, so all current guards are honored (`IsEnabled`, transition state, gaming suppression, activation grace period, and the normal peek/unpeek toggle).
- `Win32TrayIcon.IsLeftClick(lParam)`: recognizes `NIN_SELECT` / `NIN_KEYSELECT` (sent under `NOTIFYICON_VERSION_4`, which is already requested).
- `TrayIcon.OnMessage`: dispatches left-click to `TogglePeek`.

## Testing
- `dotnet publish -c Release -r win-x64` (NativeAOT) — no warnings/errors.
- Manual: left-click tray icon peeks; left-click again restores. Right-click still opens the menu. Balloon click still opens the update page.