### PR TITLE
Add global hotkey support (default Ctrl+f12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ When Windows is in dark mode, the tray menu also follows the system theme when s
 ## What's New
 
 - **Small Native AOT single-file builds** for both x64 and ARM64
+- **Global hotkey** — optional `Ctrl+Alt+P` shortcut toggles peek from anywhere (enable via tray menu)
 - **Peek on Taskbar Click** — optional trigger from empty taskbar space
 - **Dark tray menu support** — follows Windows dark mode when available
 - **Taskbar button Show Desktop** — bypasses keyboard remappers (PowerToys Keyboard Manager, etc.)
@@ -160,7 +161,7 @@ PRs welcome! Current status and next ideas:
 - [x] GitHub release-based update checks
 - [x] Works with PowerToys Keyboard Manager (keyboard remapping)
 - [ ] Smooth minimize/restore animations (slide/fade)
-- [ ] Hotkey support (e.g., `Ctrl+F12` to toggle peek)
+- [x] Hotkey support (e.g., `Ctrl+Alt+P` to toggle peek)
 - [ ] Per-monitor peek (only minimize windows on the clicked monitor)
 - [ ] Exclude specific apps from being minimized
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ When Windows is in dark mode, the tray menu also follows the system theme when s
 ## What's New
 
 - **Small Native AOT single-file builds** for both x64 and ARM64
-- **Global hotkey** — optional `Ctrl+Alt+P` shortcut toggles peek from anywhere (enable via tray menu)
+- **Global hotkey** — optional `Ctrl+F12` shortcut toggles peek from anywhere (enable via tray menu)
 - **Peek on Taskbar Click** — optional trigger from empty taskbar space
 - **Dark tray menu support** — follows Windows dark mode when available
 - **Taskbar button Show Desktop** — bypasses keyboard remappers (PowerToys Keyboard Manager, etc.)
@@ -161,7 +161,7 @@ PRs welcome! Current status and next ideas:
 - [x] GitHub release-based update checks
 - [x] Works with PowerToys Keyboard Manager (keyboard remapping)
 - [ ] Smooth minimize/restore animations (slide/fade)
-- [x] Hotkey support (e.g., `Ctrl+Alt+P` to toggle peek)
+- [x] Hotkey support (e.g., `Ctrl+F12` to toggle peek)
 - [ ] Per-monitor peek (only minimize windows on the clicked monitor)
 - [ ] Exclude specific apps from being minimized
 

--- a/src/PeekDesktop/DesktopPeek.cs
+++ b/src/PeekDesktop/DesktopPeek.cs
@@ -43,6 +43,12 @@ public sealed class DesktopPeek : IDisposable
     public bool IsPeeking => _isPeeking;
     public PeekMode PeekMode { get; set; }
 
+    /// <summary>
+    /// Toggles peek state as if the user had clicked the desktop wallpaper.
+    /// Honors the same enabled / transition / gaming guards as a real desktop click.
+    /// </summary>
+    public void TogglePeek() => OnDesktopClicked(this, EventArgs.Empty);
+
     public DesktopPeek(Settings settings)
     {
         PeekMode = NormalizePeekMode(settings.PeekMode);

--- a/src/PeekDesktop/HotKey.cs
+++ b/src/PeekDesktop/HotKey.cs
@@ -1,0 +1,142 @@
+using System;
+
+namespace PeekDesktop;
+
+/// <summary>
+/// Wraps the Win32 <c>RegisterHotKey</c> API to provide a global toggle
+/// hotkey. Uses <c>MOD_NOREPEAT</c> so holding the combo fires once per press.
+/// </summary>
+/// <remarks>
+/// We intentionally use the registered-hotkey API rather than a low-level
+/// keyboard hook. Peek toggling is a single-shot action, so we don't need
+/// to observe, swallow, or synthesize keystrokes — which means we avoid
+/// every low-level-hook pitfall (injection filtering, stuck modifiers,
+/// focus-loss cleanup, SendInput failures, etc.).
+/// </remarks>
+internal sealed class HotKey : IDisposable
+{
+    private const int HotKeyId = 0xBEEF;
+
+    private readonly Win32MessageLoop _messageLoop;
+    private bool _registered;
+    private uint _modifiers;
+    private uint _vk;
+
+    public event Action? Pressed;
+
+    public bool IsRegistered => _registered;
+
+    public HotKey(Win32MessageLoop messageLoop)
+    {
+        _messageLoop = messageLoop;
+        _messageLoop.MessageReceived += OnMessage;
+    }
+
+    /// <summary>
+    /// Registers the hotkey. Returns true on success, false if the combo
+    /// is already claimed by another process (or registration otherwise fails).
+    /// </summary>
+    public bool Register(uint modifiers, uint virtualKey)
+    {
+        Unregister();
+
+        _modifiers = modifiers;
+        _vk = virtualKey;
+
+        if (modifiers == 0 || virtualKey == 0)
+        {
+            AppDiagnostics.Log("Hotkey registration skipped: modifiers or vk is zero");
+            return false;
+        }
+
+        bool ok = NativeMethods.RegisterHotKey(
+            _messageLoop.Handle,
+            HotKeyId,
+            modifiers | NativeMethods.MOD_NOREPEAT,
+            virtualKey);
+
+        if (!ok)
+        {
+            int err = System.Runtime.InteropServices.Marshal.GetLastWin32Error();
+            AppDiagnostics.Log($"RegisterHotKey failed ({Describe(modifiers, virtualKey)}): Win32 error {err}");
+            _registered = false;
+            return false;
+        }
+
+        _registered = true;
+        AppDiagnostics.Log($"Hotkey registered: {Describe(modifiers, virtualKey)}");
+        return true;
+    }
+
+    public void Unregister()
+    {
+        if (!_registered)
+            return;
+
+        if (!NativeMethods.UnregisterHotKey(_messageLoop.Handle, HotKeyId))
+        {
+            int err = System.Runtime.InteropServices.Marshal.GetLastWin32Error();
+            AppDiagnostics.Log($"UnregisterHotKey failed: Win32 error {err}");
+        }
+        else
+        {
+            AppDiagnostics.Log($"Hotkey unregistered: {Describe(_modifiers, _vk)}");
+        }
+
+        _registered = false;
+    }
+
+    private (bool handled, IntPtr result) OnMessage(IntPtr hwnd, uint msg, IntPtr wParam, IntPtr lParam)
+    {
+        if (msg == NativeMethods.WM_HOTKEY && wParam.ToInt32() == HotKeyId)
+        {
+            Pressed?.Invoke();
+            return (true, IntPtr.Zero);
+        }
+
+        return (false, IntPtr.Zero);
+    }
+
+    public void Dispose()
+    {
+        _messageLoop.MessageReceived -= OnMessage;
+        Unregister();
+    }
+
+    public static string Describe(uint modifiers, uint vk)
+    {
+        var parts = new System.Text.StringBuilder();
+        if ((modifiers & NativeMethods.MOD_CONTROL) != 0) parts.Append("Ctrl+");
+        if ((modifiers & NativeMethods.MOD_ALT) != 0) parts.Append("Alt+");
+        if ((modifiers & NativeMethods.MOD_SHIFT) != 0) parts.Append("Shift+");
+        if ((modifiers & NativeMethods.MOD_WIN) != 0) parts.Append("Win+");
+        parts.Append(VkToDisplayName(vk));
+        return parts.ToString();
+    }
+
+    private static string VkToDisplayName(uint vk)
+    {
+        // Printable ASCII range for letters and digits — RegisterHotKey uses
+        // the same values as VK_A..VK_Z (0x41..0x5A) and VK_0..VK_9 (0x30..0x39).
+        if ((vk >= 0x30 && vk <= 0x39) || (vk >= 0x41 && vk <= 0x5A))
+            return ((char)vk).ToString();
+
+        return vk switch
+        {
+            0x20 => "Space",
+            0x70 => "F1",
+            0x71 => "F2",
+            0x72 => "F3",
+            0x73 => "F4",
+            0x74 => "F5",
+            0x75 => "F6",
+            0x76 => "F7",
+            0x77 => "F8",
+            0x78 => "F9",
+            0x79 => "F10",
+            0x7A => "F11",
+            0x7B => "F12",
+            _ => $"VK_0x{vk:X2}"
+        };
+    }
+}

--- a/src/PeekDesktop/NativeMethods.cs
+++ b/src/PeekDesktop/NativeMethods.cs
@@ -70,7 +70,20 @@ internal static class NativeMethods
     private const uint KEYEVENTF_EXTENDEDKEY = 0x0001;
     private const uint KEYEVENTF_KEYUP = 0x0002;
     private const ushort VK_LWIN = 0x5B;
+    private const ushort VK_RWIN = 0x5C;
     private const ushort VK_D = 0x44;
+    private const ushort VK_SHIFT = 0x10;
+    private const ushort VK_CONTROL = 0x11;
+    private const ushort VK_MENU = 0x12;
+    private const ushort VK_LSHIFT = 0xA0;
+    private const ushort VK_RSHIFT = 0xA1;
+    private const ushort VK_LCONTROL = 0xA2;
+    private const ushort VK_RCONTROL = 0xA3;
+    private const ushort VK_LMENU = 0xA4;
+    private const ushort VK_RMENU = 0xA5;
+
+    [DllImport("user32.dll")]
+    private static extern short GetAsyncKeyState(int vKey);
 
     // --- MSAA accessible roles ---
     public const int ROLE_SYSTEM_LISTITEM = 0x22;
@@ -624,6 +637,30 @@ internal static class NativeMethods
 
     private static bool TryToggleDesktopWithWinD()
     {
+        // Modifier hygiene: if another key (e.g. a global hotkey like Ctrl+F12)
+        // caused us to be invoked while the user is still physically holding
+        // Ctrl / Alt / Shift / Win, injecting Win+D would be interpreted by
+        // Windows as (for example) Ctrl+Win+D — which creates a new virtual
+        // desktop. Release any physically-held modifier first so the injected
+        // Win+D is seen in isolation. The user's physical key-up will still
+        // fire later and is harmless.
+        var prelude = new System.Collections.Generic.List<INPUT>(8);
+        AddModifierReleaseIfDown(prelude, VK_LCONTROL);
+        AddModifierReleaseIfDown(prelude, VK_RCONTROL);
+        AddModifierReleaseIfDown(prelude, VK_LMENU);
+        AddModifierReleaseIfDown(prelude, VK_RMENU);
+        AddModifierReleaseIfDown(prelude, VK_LSHIFT);
+        AddModifierReleaseIfDown(prelude, VK_RSHIFT);
+        AddModifierReleaseIfDown(prelude, VK_LWIN, extendedKey: true);
+        AddModifierReleaseIfDown(prelude, VK_RWIN, extendedKey: true);
+
+        if (prelude.Count > 0)
+        {
+            INPUT[] preludeArr = prelude.ToArray();
+            uint preSent = SendInput((uint)preludeArr.Length, preludeArr, Marshal.SizeOf<INPUT>());
+            AppDiagnostics.Log($"Released {preSent}/{preludeArr.Length} held modifier(s) before Win+D injection");
+        }
+
         INPUT[] inputs =
         [
             CreateKeyInput(VK_LWIN, keyUp: false, extendedKey: true),
@@ -641,6 +678,13 @@ internal static class NativeMethods
         }
 
         return true;
+    }
+
+    private static void AddModifierReleaseIfDown(System.Collections.Generic.List<INPUT> list, ushort vk, bool extendedKey = false)
+    {
+        // High bit of GetAsyncKeyState = currently down.
+        if ((GetAsyncKeyState(vk) & 0x8000) != 0)
+            list.Add(CreateKeyInput(vk, keyUp: true, extendedKey: extendedKey));
     }
 
     private static IntPtr FindAncestorByClassName(IntPtr hwnd, string className)

--- a/src/PeekDesktop/NativeMethods.cs
+++ b/src/PeekDesktop/NativeMethods.cs
@@ -17,6 +17,22 @@ internal static class NativeMethods
     // --- Mouse messages ---
     public const int WM_LBUTTONDOWN = 0x0201;
 
+    // --- Hotkey ---
+    public const uint WM_HOTKEY = 0x0312;
+    public const uint MOD_ALT = 0x0001;
+    public const uint MOD_CONTROL = 0x0002;
+    public const uint MOD_SHIFT = 0x0004;
+    public const uint MOD_WIN = 0x0008;
+    public const uint MOD_NOREPEAT = 0x4000;
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
     // --- ShowWindow commands ---
     public const int SW_SHOWNORMAL = 1;
     public const int SW_MAXIMIZE = 3;

--- a/src/PeekDesktop/Program.cs
+++ b/src/PeekDesktop/Program.cs
@@ -58,6 +58,7 @@ public static class Program
     private static DesktopPeek? _desktopPeek;
     private static TrayIcon? _trayIcon;
     private static AppUpdater? _appUpdater;
+    private static HotKey? _hotKey;
 
     private static void Initialize(Win32MessageLoop messageLoop)
     {
@@ -65,7 +66,26 @@ public static class Program
         Settings.SetAutoStart(settings.StartWithWindows);
         _desktopPeek = new DesktopPeek(settings);
         _appUpdater = new AppUpdater(messageLoop);
-        _trayIcon = new TrayIcon(messageLoop, _desktopPeek, _appUpdater, settings, () => messageLoop.Quit());
+        _hotKey = new HotKey(messageLoop);
+        _hotKey.Pressed += () =>
+        {
+            AppDiagnostics.Log("Global hotkey pressed; toggling peek");
+            _desktopPeek.TogglePeek();
+        };
+        _trayIcon = new TrayIcon(messageLoop, _desktopPeek, _appUpdater, _hotKey, settings, () => messageLoop.Quit());
+
+        if (settings.HotkeyEnabled)
+        {
+            if (!_hotKey.Register(settings.HotkeyModifiers, settings.HotkeyVk))
+            {
+                // Another app owns the combo. Persist the "off" state so we
+                // don't spam the user on every launch; they can re-enable it
+                // from the tray menu once the conflict is resolved.
+                AppDiagnostics.Log("Hotkey disabled on startup due to registration failure");
+                settings.HotkeyEnabled = false;
+                settings.Save();
+            }
+        }
 
         if (settings.Enabled)
             _desktopPeek.Start();

--- a/src/PeekDesktop/Settings.cs
+++ b/src/PeekDesktop/Settings.cs
@@ -25,6 +25,13 @@ public sealed class Settings
     public bool PeekOnTaskbarClick { get; set; } = false;
     public PeekMode PeekMode { get; set; } = PeekMode.NativeShowDesktop;
 
+    // Global hotkey: defaults to Ctrl+Alt+P ('P' = 0x50), disabled by default
+    // to avoid claiming a combo the user may already be using. Turn it on via
+    // the tray menu.
+    public bool HotkeyEnabled { get; set; } = false;
+    public uint HotkeyModifiers { get; set; } = 0x0001 /* MOD_ALT */ | 0x0002 /* MOD_CONTROL */;
+    public uint HotkeyVk { get; set; } = 0x50; // 'P'
+
     public static Settings Load()
     {
         try
@@ -121,6 +128,21 @@ public sealed class Settings
                 reader.Read();
                 settings.PeekMode = (PeekMode)reader.GetInt32();
             }
+            else if (reader.ValueTextEquals("HotkeyEnabled"u8))
+            {
+                reader.Read();
+                settings.HotkeyEnabled = reader.GetBoolean();
+            }
+            else if (reader.ValueTextEquals("HotkeyModifiers"u8))
+            {
+                reader.Read();
+                settings.HotkeyModifiers = reader.GetUInt32();
+            }
+            else if (reader.ValueTextEquals("HotkeyVk"u8))
+            {
+                reader.Read();
+                settings.HotkeyVk = reader.GetUInt32();
+            }
             else
             {
                 reader.Skip();
@@ -142,6 +164,9 @@ public sealed class Settings
         writer.WriteBoolean("PauseWhileFullscreenAppActive"u8, PauseWhileFullscreenAppActive);
         writer.WriteBoolean("PeekOnTaskbarClick"u8, PeekOnTaskbarClick);
         writer.WriteNumber("PeekMode"u8, (int)PeekMode);
+        writer.WriteBoolean("HotkeyEnabled"u8, HotkeyEnabled);
+        writer.WriteNumber("HotkeyModifiers"u8, HotkeyModifiers);
+        writer.WriteNumber("HotkeyVk"u8, HotkeyVk);
         writer.WriteEndObject();
 
         writer.Flush();

--- a/src/PeekDesktop/Settings.cs
+++ b/src/PeekDesktop/Settings.cs
@@ -25,12 +25,12 @@ public sealed class Settings
     public bool PeekOnTaskbarClick { get; set; } = false;
     public PeekMode PeekMode { get; set; } = PeekMode.NativeShowDesktop;
 
-    // Global hotkey: defaults to Ctrl+Alt+P ('P' = 0x50), disabled by default
+    // Global hotkey: defaults to Ctrl+F12 (VK_F12 = 0x7B), disabled by default
     // to avoid claiming a combo the user may already be using. Turn it on via
     // the tray menu.
     public bool HotkeyEnabled { get; set; } = false;
-    public uint HotkeyModifiers { get; set; } = 0x0001 /* MOD_ALT */ | 0x0002 /* MOD_CONTROL */;
-    public uint HotkeyVk { get; set; } = 0x50; // 'P'
+    public uint HotkeyModifiers { get; set; } = 0x0002 /* MOD_CONTROL */;
+    public uint HotkeyVk { get; set; } = 0x7B; // VK_F12
 
     public static Settings Load()
     {

--- a/src/PeekDesktop/TrayIcon.cs
+++ b/src/PeekDesktop/TrayIcon.cs
@@ -16,6 +16,7 @@ internal sealed class TrayIcon : IDisposable
     private const uint ID_DOUBLECLICK = 3;
     private const uint ID_GAME_GUARD = 4;
     private const uint ID_TASKBAR_CLICK = 5;
+    private const uint ID_HOTKEY = 6;
     private const uint ID_MODE_MINIMIZE = 10;
     private const uint ID_MODE_FLYAWAY = 11;
     private const uint ID_MODE_NATIVE = 12;
@@ -27,14 +28,16 @@ internal sealed class TrayIcon : IDisposable
     private readonly Win32MessageLoop _messageLoop;
     private readonly DesktopPeek _desktopPeek;
     private readonly AppUpdater _appUpdater;
+    private readonly HotKey _hotKey;
     private readonly Settings _settings;
     private readonly Action _exitAction;
 
-    public TrayIcon(Win32MessageLoop messageLoop, DesktopPeek desktopPeek, AppUpdater appUpdater, Settings settings, Action exitAction)
+    public TrayIcon(Win32MessageLoop messageLoop, DesktopPeek desktopPeek, AppUpdater appUpdater, HotKey hotKey, Settings settings, Action exitAction)
     {
         _messageLoop = messageLoop;
         _desktopPeek = desktopPeek;
         _appUpdater = appUpdater;
+        _hotKey = hotKey;
         _settings = settings;
         _exitAction = exitAction;
 
@@ -99,6 +102,7 @@ internal sealed class TrayIcon : IDisposable
         menu.AddItem(ID_STARTUP, "Start with Windows", ToggleStartup, _settings.StartWithWindows);
         menu.AddItem(ID_DOUBLECLICK, "Require Double-Click", ToggleDoubleClick, _settings.RequireDoubleClick);
         menu.AddItem(ID_TASKBAR_CLICK, "Peek on Taskbar Click", ToggleTaskbarClick, _settings.PeekOnTaskbarClick);
+        menu.AddItem(ID_HOTKEY, $"Peek Hotkey ({HotKey.Describe(_settings.HotkeyModifiers, _settings.HotkeyVk)})", ToggleHotkey, _settings.HotkeyEnabled);
         menu.AddItem(ID_GAME_GUARD, "Pause While Gaming / Full-Screen", ToggleGameGuard, _settings.PauseWhileFullscreenAppActive);
         menu.AddSeparator();
         menu.AddItem(ID_MODE_NATIVE, "Show Desktop (Explorer)", () => SetPeekMode(PeekMode.NativeShowDesktop), _settings.PeekMode == PeekMode.NativeShowDesktop);
@@ -150,6 +154,31 @@ internal sealed class TrayIcon : IDisposable
     {
         _settings.PeekOnTaskbarClick = !_settings.PeekOnTaskbarClick;
         _desktopPeek.SetPeekOnTaskbarClick(_settings.PeekOnTaskbarClick);
+        _settings.Save();
+    }
+
+    private void ToggleHotkey()
+    {
+        _settings.HotkeyEnabled = !_settings.HotkeyEnabled;
+
+        if (_settings.HotkeyEnabled)
+        {
+            bool ok = _hotKey.Register(_settings.HotkeyModifiers, _settings.HotkeyVk);
+            if (!ok)
+            {
+                // Another app owns the combo; revert and notify the user.
+                _settings.HotkeyEnabled = false;
+                string combo = HotKey.Describe(_settings.HotkeyModifiers, _settings.HotkeyVk);
+                _trayIcon.ShowBalloon(
+                    "PeekDesktop Hotkey Unavailable",
+                    $"The {combo} shortcut is already in use by another application.");
+            }
+        }
+        else
+        {
+            _hotKey.Unregister();
+        }
+
         _settings.Save();
     }
 


### PR DESCRIPTION
Fixes https://github.com/shanselman/PeekDesktop/issues/39

## What
Adds an optional **global hotkey** (default `Ctrl+F12`) that toggles peek from anywhere, matching the roadmap item in the README. Off by default; users opt in via the tray menu.

Ticks `- [x] Hotkey support` on the README roadmap.

## Why `RegisterHotKey` and not a low-level keyboard hook
Peek is a single-shot toggle. We don't need to observe, suppress, or synthesize keystrokes, so `RegisterHotKey` is the right tool. This sidesteps every LL-hook pitfall:

- No injection filtering concerns (`LLKHF_INJECTED`)
- No risk of stuck modifiers from swallowed keys
- No focus-loss cleanup needed
- No `SendInput` failure paths
- Combo is consumed by Windows for us; downstream apps don't see it — but no modifier state is manipulated because we never synthesize input from the hook path

`MOD_NOREPEAT` is set so holding the combo fires once per press (no re-peek storm).

## Modifier hygiene for the Win+D fallback
The `NativeShowDesktop` peek mode's fallback path injects `Win+D` via `SendInput`. When a hotkey like `Ctrl+F12` triggers the peek while the user is still physically holding Ctrl, Windows combined the injected `Win+D` with the held Ctrl and interpreted it as `Ctrl+Win+D` — which creates a new virtual desktop. Before injecting `Win+D` we now `GetAsyncKeyState` each of LCtrl/RCtrl/LAlt/RAlt/LShift/RShift/LWin/RWin and inject a `KEYUP` for any that is physically held. The user's real key-up arrives naturally later and is harmless.

## Changes
- `HotKey.cs`: thin wrapper over `RegisterHotKey` / `UnregisterHotKey` listening for `WM_HOTKEY` on the existing message-loop window. Exposes `Pressed` event and `Describe()` for display.
- `NativeMethods.cs`: `WM_HOTKEY`, `MOD_*` constants and `Register/UnregisterHotKey` P/Invokes; `GetAsyncKeyState` + modifier VKs; modifier-release prelude before the `Win+D` injection.
- `Settings.cs`: new `HotkeyEnabled` (default false), `HotkeyModifiers` (default `MOD_CONTROL`), `HotkeyVk` (default `VK_F12`). Round-trips through the existing JSON reader/writer.
- `DesktopPeek.cs`: new public `TogglePeek()` that routes through `OnDesktopClicked` so all enabled / transition / gaming guards are honored — shared by the hotkey path.
- `TrayIcon.cs`: `Peek Hotkey (Ctrl+F12)` menu item toggles registration. Balloon-notifies and reverts if another app owns the combo.
- `Program.cs`: registers the hotkey at startup when enabled. If registration fails on launch, persists `HotkeyEnabled = false` so the user isn't spammed every launch; they re-enable via the menu once the conflict is resolved.
- `README.md`: adds the feature to "What's New" and checks the roadmap item.

## Testing
- `dotnet publish -c Release -r win-x64` (NativeAOT) — no warnings/errors.
- Manual:
  - Enable via tray menu → `Ctrl+F12` from any foreground app toggles peek and restore.
  - Holding the combo fires once (`MOD_NOREPEAT`).
  - Disable via menu → combo is released.
  - Simulated conflict (another app registered first): startup logs + persists off; menu toggle balloon-notifies and reverts.
  - Verified no virtual-desktop creation on `Ctrl+F12` (modifier-hygiene prelude releases the held Ctrl before injecting `Win+D`).