### PR TITLE
Add Chinese (zh) localization for all UI strings

### DIFF
--- a/src/PeekDesktop/AppUpdater.cs
+++ b/src/PeekDesktop/AppUpdater.cs
@@ -47,8 +47,8 @@ internal sealed class AppUpdater
             {
                 NativeMethods.MessageBoxW(
                     IntPtr.Zero,
-                    "PeekDesktop is already checking for updates.",
-                    "PeekDesktop Update",
+                    Lang.Update_AlreadyChecking,
+                    Lang.Update_AlreadyChecking_Title,
                     NativeMethods.MB_OK | NativeMethods.MB_ICONINFORMATION);
             }
 
@@ -76,8 +76,8 @@ internal sealed class AppUpdater
                 {
                     NativeMethods.MessageBoxW(
                         IntPtr.Zero,
-                        $"You're already on the latest version of PeekDesktop ({currentVersion}).",
-                        "PeekDesktop Update",
+                        Lang.Update_UpToDate(currentVersion),
+                        Lang.Update_UpToDate_Title,
                         NativeMethods.MB_OK | NativeMethods.MB_ICONINFORMATION);
                 }
 
@@ -101,8 +101,8 @@ internal sealed class AppUpdater
             {
                 NativeMethods.MessageBoxW(
                     IntPtr.Zero,
-                    $"PeekDesktop couldn't check for updates.\n\n{ex.Message}",
-                    "Update Error",
+                    $"{Lang.Update_CheckFailed}\n\n{ex.Message}",
+                    Lang.Update_CheckFailed_Title,
                     NativeMethods.MB_OK | NativeMethods.MB_ICONERROR);
             }
         }
@@ -125,8 +125,8 @@ internal sealed class AppUpdater
 
         int result = NativeMethods.MessageBoxW(
             IntPtr.Zero,
-            $"PeekDesktop {latestVersion} is available.\n\nDownload and install it now? PeekDesktop will restart automatically.",
-            "Update Available",
+            Lang.Update_AvailableBody(latestVersion),
+            Lang.Update_Available_Title,
             NativeMethods.MB_YESNO | NativeMethods.MB_ICONINFORMATION);
 
         if (result != NativeMethods.IDYES)
@@ -226,9 +226,8 @@ internal sealed class AppUpdater
                 {
                     NativeMethods.MessageBoxW(
                         IntPtr.Zero,
-                        "The update was installed but PeekDesktop could not restart automatically.\n\n" +
-                        "Please start PeekDesktop manually.",
-                        "Update Installed",
+                        Lang.Update_RestartFailed,
+                        Lang.Update_RestartFailed_Title,
                         NativeMethods.MB_OK | NativeMethods.MB_ICONINFORMATION);
                     return;
                 }
@@ -269,8 +268,8 @@ internal sealed class AppUpdater
 
             NativeMethods.MessageBoxW(
                 IntPtr.Zero,
-                $"PeekDesktop couldn't install the update.\n\n{ex.Message}",
-                "Update Error",
+                $"{Lang.Update_InstallFailed}\n\n{ex.Message}",
+                Lang.Update_InstallFailed_Title,
                 NativeMethods.MB_OK | NativeMethods.MB_ICONERROR);
         }
         finally

--- a/src/PeekDesktop/Lang.cs
+++ b/src/PeekDesktop/Lang.cs
@@ -1,0 +1,118 @@
+namespace PeekDesktop;
+
+/// <summary>
+/// Provides localized UI strings. Detects Chinese system language at startup;
+/// falls back to English for all other locales.
+/// </summary>
+internal static class Lang
+{
+    private static readonly bool IsChinese = NativeMethods.IsSystemChinese();
+
+    // --- Tray Menu Items ---
+
+    public static string Tray_Enabled => IsChinese ? "已启用" : "Enabled";
+    public static string Tray_StartWithWindows => IsChinese ? "开机自启动" : "Start with Windows";
+    public static string Tray_RequireDoubleClick => IsChinese ? "需要双击" : "Require Double-Click";
+    public static string Tray_PeekOnDesktopClick => IsChinese ? "点击桌面时预览" : "Peek on Desktop Click";
+    public static string Tray_PeekOnTaskbarClick => IsChinese ? "点击任务栏时预览" : "Peek on Taskbar Click";
+    public static string Tray_RestoreOnAppSwitch => IsChinese ? "切换应用时恢复所有窗口" : "Restore All Windows on App Switch";
+    public static string Tray_PauseWhileGaming => IsChinese ? "游戏/全屏时暂停" : "Pause While Gaming / Full-Screen";
+    public static string Tray_ShowDesktop => IsChinese ? "显示桌面 (资源管理器)" : "Show Desktop (Explorer)";
+    public static string Tray_FlyAway => IsChinese ? "窗口飞走 (实验性)" : "Fly Away (Experimental)";
+    public static string Tray_About => IsChinese ? "关于 PeekDesktop" : "About PeekDesktop";
+    public static string Tray_CheckForUpdates => IsChinese ? "检查更新" : "Check for Updates";
+    public static string Tray_AutoCheckForUpdates => IsChinese ? "自动检查更新" : "Auto-Check for Updates";
+    public static string Tray_Exit => IsChinese ? "退出" : "Exit";
+
+    // --- Tray Tooltip ---
+
+    public static string TrayTooltip_Initial => "PeekDesktop";
+
+    public static string TrayTooltip_Mode(PeekMode mode) =>
+        $"PeekDesktop - {PeekModeDisplayName(mode)}";
+
+    public static string PeekModeDisplayName(PeekMode mode) => mode switch
+    {
+        PeekMode.Minimize => IsChinese ? "经典最小化" : "Classic Minimize",
+        PeekMode.FlyAway => IsChinese ? "窗口飞走" : "Fly Away",
+        PeekMode.NativeShowDesktop => IsChinese ? "原生显示桌面" : "Native Show Desktop",
+        _ => IsChinese ? "预览" : "Peek"
+    };
+
+    public static string Version_DevBuild => IsChinese ? "开发版" : "dev build";
+    public static string Version_Unknown => IsChinese ? "未知" : "unknown";
+
+    // --- About Dialog ---
+
+    public static string About_Title => IsChinese ? "关于 PeekDesktop" : "About PeekDesktop";
+
+    public static string About_Body(string version) => IsChinese
+        ? $"PeekDesktop v{version}\n\n" +
+          "点击桌面壁纸即可预览桌面，\n" +
+          "如同 macOS Sonoma 一样。\n\n" +
+          "点击任意窗口或任务栏即可恢复。\n" +
+          "预览模式可在资源管理器显示桌面\n" +
+          "和窗口飞走模式之间切换。\n\n" +
+          "更新来自 GitHub Releases。\n\n" +
+          "github.com/shanselman/PeekDesktop"
+        : $"PeekDesktop v{version}\n\n" +
+          "Click your desktop wallpaper to peek at your desktop,\n" +
+          "just like macOS Sonoma.\n\n" +
+          "Click any window or the taskbar to restore.\n" +
+          "Peek Style lets you switch between Explorer show desktop\n" +
+          "and fly-away mode.\n\n" +
+          "Updates come from GitHub Releases.\n\n" +
+          "github.com/shanselman/PeekDesktop";
+
+    // --- Balloon Notification ---
+
+    public static string Balloon_UpdateTitle => IsChinese ? "PeekDesktop 有可用更新" : "PeekDesktop Update Available";
+    public static string Balloon_UpdateBody(string version) => IsChinese
+        ? $"版本 {version} 已可用。点击此处下载并安装。"
+        : $"Version {version} is available. Click here to download and install.";
+
+    // --- Program.cs Fatal Error ---
+
+    public static string Fatal_Title => IsChinese ? "PeekDesktop 无法启动" : "PeekDesktop failed to start";
+
+    // --- AppUpdater Dialogs ---
+
+    public static string Update_AlreadyChecking => IsChinese
+        ? "PeekDesktop 正在检查更新。" : "PeekDesktop is already checking for updates.";
+    public static string Update_AlreadyChecking_Title => IsChinese
+        ? "PeekDesktop 更新" : "PeekDesktop Update";
+
+    public static string Update_UpToDate(string version) => IsChinese
+        ? $"你已经在使用最新版本的 PeekDesktop ({version})。"
+        : $"You're already on the latest version of PeekDesktop ({version}).";
+    public static string Update_UpToDate_Title => IsChinese
+        ? "PeekDesktop 更新" : "PeekDesktop Update";
+
+    public static string Update_CheckFailed => IsChinese
+        ? "PeekDesktop 无法检查更新。" : "PeekDesktop couldn't check for updates.";
+    public static string Update_CheckFailed_Title => IsChinese
+        ? "更新错误" : "Update Error";
+
+    public static string Update_AvailableBody(string version) => IsChinese
+        ? $"PeekDesktop {version} 已可用。\n\n是否立即下载并安装？PeekDesktop 将自动重启。"
+        : $"PeekDesktop {version} is available.\n\nDownload and install it now? PeekDesktop will restart automatically.";
+    public static string Update_Available_Title => IsChinese
+        ? "有可用更新" : "Update Available";
+
+    public static string Update_RestartFailed => IsChinese
+        ? "更新已安装，但 PeekDesktop 无法自动重启。\n\n请手动启动 PeekDesktop。"
+        : "The update was installed but PeekDesktop could not restart automatically.\n\n" +
+          "Please start PeekDesktop manually.";
+    public static string Update_RestartFailed_Title => IsChinese
+        ? "更新已安装" : "Update Installed";
+
+    public static string Update_InstallFailed => IsChinese
+        ? "PeekDesktop 无法安装更新。" : "PeekDesktop couldn't install the update.";
+    public static string Update_InstallFailed_Title => IsChinese
+        ? "更新错误" : "Update Error";
+
+    // --- VirtualDesktopService ---
+
+    public static string VirtualDesktop_Name => IsChinese
+        ? "PeekDesktop (实验性)" : "PeekDesktop (Experimental)";
+}

--- a/src/PeekDesktop/NativeMethods.cs
+++ b/src/PeekDesktop/NativeMethods.cs
@@ -1074,4 +1074,16 @@ internal static class NativeMethods
 
         return (productVersion, fileVersion);
     }
+
+    // --- System language detection ---
+
+    [DllImport("kernel32.dll")]
+    private static extern ushort GetUserDefaultUILanguage();
+
+    public static bool IsSystemChinese()
+    {
+        ushort langId = GetUserDefaultUILanguage();
+        byte primaryLang = (byte)(langId & 0xFF);
+        return primaryLang == 0x04; // LANG_CHINESE
+    }
 }

--- a/src/PeekDesktop/Program.cs
+++ b/src/PeekDesktop/Program.cs
@@ -166,7 +166,7 @@ public static class Program
         NativeMethods.MessageBoxW(
             IntPtr.Zero,
             $"{context}\n\n{ex.Message}",
-            "PeekDesktop failed to start",
+            Lang.Fatal_Title,
             NativeMethods.MB_OK | NativeMethods.MB_ICONERROR);
     }
 }

--- a/src/PeekDesktop/TrayIcon.cs
+++ b/src/PeekDesktop/TrayIcon.cs
@@ -50,8 +50,8 @@ internal sealed class TrayIcon : IDisposable
         _appUpdater.UpdateAvailable += (_, e) =>
         {
             _trayIcon.ShowBalloon(
-                "PeekDesktop Update Available",
-                $"Version {e.Version} is available. Click here to download and install.");
+                Lang.Balloon_UpdateTitle,
+                Lang.Balloon_UpdateBody(e.Version));
         };
 
         // Let the updater remove the tray icon before exiting during update
@@ -67,7 +67,7 @@ internal sealed class TrayIcon : IDisposable
     private void TryAddTrayIcon(bool scheduleRetryOnFailure)
     {
         IntPtr hIcon = Win32Icon.CreateTrayIcon();
-        if (_trayIcon.Add(hIcon, "PeekDesktop"))
+        if (_trayIcon.Add(hIcon, Lang.TrayTooltip_Initial))
             return;
 
         if (!scheduleRetryOnFailure)
@@ -101,22 +101,22 @@ internal sealed class TrayIcon : IDisposable
     {
         using var menu = new Win32Menu();
 
-        menu.AddItem(ID_ENABLED, "Enabled", ToggleEnabled, _settings.Enabled);
-        menu.AddItem(ID_STARTUP, "Start with Windows", ToggleStartup, _settings.StartWithWindows);
-        menu.AddItem(ID_DOUBLECLICK, "Require Double-Click", ToggleDoubleClick, _settings.RequireDoubleClick);
-        menu.AddItem(ID_DESKTOP_CLICK, "Peek on Desktop Click", ToggleDesktopClick, _settings.PeekOnDesktopClick);
-        menu.AddItem(ID_TASKBAR_CLICK, "Peek on Taskbar Click", ToggleTaskbarClick, _settings.PeekOnTaskbarClick);
-        menu.AddItem(ID_RESTORE_ON_APP_OPEN, "Restore All Windows on App Switch", ToggleRestoreOnAppOpen, _settings.RestoreHiddenWindowsOnAppOpen);
-        menu.AddItem(ID_GAME_GUARD, "Pause While Gaming / Full-Screen", ToggleGameGuard, _settings.PauseWhileFullscreenAppActive);
+        menu.AddItem(ID_ENABLED, Lang.Tray_Enabled, ToggleEnabled, _settings.Enabled);
+        menu.AddItem(ID_STARTUP, Lang.Tray_StartWithWindows, ToggleStartup, _settings.StartWithWindows);
+        menu.AddItem(ID_DOUBLECLICK, Lang.Tray_RequireDoubleClick, ToggleDoubleClick, _settings.RequireDoubleClick);
+        menu.AddItem(ID_DESKTOP_CLICK, Lang.Tray_PeekOnDesktopClick, ToggleDesktopClick, _settings.PeekOnDesktopClick);
+        menu.AddItem(ID_TASKBAR_CLICK, Lang.Tray_PeekOnTaskbarClick, ToggleTaskbarClick, _settings.PeekOnTaskbarClick);
+        menu.AddItem(ID_RESTORE_ON_APP_OPEN, Lang.Tray_RestoreOnAppSwitch, ToggleRestoreOnAppOpen, _settings.RestoreHiddenWindowsOnAppOpen);
+        menu.AddItem(ID_GAME_GUARD, Lang.Tray_PauseWhileGaming, ToggleGameGuard, _settings.PauseWhileFullscreenAppActive);
         menu.AddSeparator();
-        menu.AddItem(ID_MODE_NATIVE, "Show Desktop (Explorer)", () => SetPeekMode(PeekMode.NativeShowDesktop), _settings.PeekMode == PeekMode.NativeShowDesktop);
-        menu.AddItem(ID_MODE_FLYAWAY, "Fly Away (Experimental)", () => SetPeekMode(PeekMode.FlyAway), _settings.PeekMode == PeekMode.FlyAway);
+        menu.AddItem(ID_MODE_NATIVE, Lang.Tray_ShowDesktop, () => SetPeekMode(PeekMode.NativeShowDesktop), _settings.PeekMode == PeekMode.NativeShowDesktop);
+        menu.AddItem(ID_MODE_FLYAWAY, Lang.Tray_FlyAway, () => SetPeekMode(PeekMode.FlyAway), _settings.PeekMode == PeekMode.FlyAway);
         menu.AddSeparator();
-        menu.AddItem(ID_ABOUT, "About PeekDesktop", ShowAbout);
-        menu.AddItem(ID_UPDATES, "Check for Updates", CheckForUpdates);
-        menu.AddItem(ID_AUTO_UPDATES, "Auto-Check for Updates", ToggleAutoUpdates, _settings.AutoCheckForUpdates);
+        menu.AddItem(ID_ABOUT, Lang.Tray_About, ShowAbout);
+        menu.AddItem(ID_UPDATES, Lang.Tray_CheckForUpdates, CheckForUpdates);
+        menu.AddItem(ID_AUTO_UPDATES, Lang.Tray_AutoCheckForUpdates, ToggleAutoUpdates, _settings.AutoCheckForUpdates);
         menu.AddSeparator();
-        menu.AddItem(ID_EXIT, "Exit", DoExit);
+        menu.AddItem(ID_EXIT, Lang.Tray_Exit, DoExit);
 
         menu.Show(_messageLoop.Handle);
     }
@@ -180,24 +180,16 @@ internal sealed class TrayIcon : IDisposable
     {
         _settings.PeekMode = peekMode;
         _desktopPeek.SetPeekMode(peekMode);
-        _trayIcon.UpdateTooltip($"PeekDesktop - {GetPeekModeDisplayName(peekMode)}");
+        _trayIcon.UpdateTooltip(Lang.TrayTooltip_Mode(peekMode));
         _settings.Save();
     }
 
     private void ShowAbout()
     {
-        string version = GetDisplayVersion();
         NativeMethods.MessageBoxW(
             IntPtr.Zero,
-            $"PeekDesktop v{version}\n\n" +
-            "Click your desktop wallpaper to peek at your desktop,\n" +
-            "just like macOS Sonoma.\n\n" +
-            "Click any window or the taskbar to restore.\n" +
-            "Peek Style lets you switch between Explorer show desktop\n" +
-            "and fly-away mode.\n\n" +
-            "Updates come from GitHub Releases.\n\n" +
-            "github.com/shanselman/PeekDesktop",
-            "About PeekDesktop",
+            Lang.About_Body(GetDisplayVersion()),
+            Lang.About_Title,
             NativeMethods.MB_OK | NativeMethods.MB_ICONINFORMATION);
     }
 
@@ -224,7 +216,7 @@ internal sealed class TrayIcon : IDisposable
         string? version = productVersion ?? fileVersion?.ToString();
 
         if (string.IsNullOrWhiteSpace(version))
-            return "unknown";
+            return Lang.Version_Unknown;
 
         int plusIndex = version.IndexOf('+');
         version = plusIndex >= 0 ? version[..plusIndex] : version;
@@ -234,22 +226,14 @@ internal sealed class TrayIcon : IDisposable
 
         return version switch
         {
-            "1.0.0.0" => "dev build",
-            "1.0.0" => "dev build",
+            "1.0.0.0" => Lang.Version_DevBuild,
+            "1.0.0" => Lang.Version_DevBuild,
             _ => version
         };
     }
 
     private static string GetPeekModeDisplayName(PeekMode peekMode)
-    {
-        return peekMode switch
-        {
-            PeekMode.Minimize => "Classic Minimize",
-            PeekMode.FlyAway => "Fly Away",
-            PeekMode.NativeShowDesktop => "Native Show Desktop",
-            _ => "Peek"
-        };
-    }
+        => Lang.PeekModeDisplayName(peekMode);
 
     public void Dispose()
     {

--- a/src/PeekDesktop/VirtualDesktopService.cs
+++ b/src/PeekDesktop/VirtualDesktopService.cs
@@ -158,7 +158,7 @@ internal sealed class VirtualDesktopService : IDisposable
             Guid desktopId = desktop.GetId();
             _peekDesktopId = desktopId;
             _peekDesktopCreated = true;
-            TrySetDesktopName(desktop, "PeekDesktop (Experimental)");
+            TrySetDesktopName(desktop, Lang.VirtualDesktop_Name);
             AppDiagnostics.Log($"Created virtual peek desktop {desktopId}");
             return desktop;
         }


### PR DESCRIPTION
## Summary
- Adds automatic Chinese localization for all ~40 user-facing UI strings
- Detects Windows system UI language via `GetUserDefaultUILanguage` — no settings or manual switch needed
- Falls back to English on non-Chinese systems (zh-CN, zh-TW, zh-HK, zh-SG, zh-MO all supported)

## Implementation
- **`Lang.cs`** — new static class with localized string properties, using a simple boolean branch (`IsChinese ? "中文" : "English"`)
- **`NativeMethods.cs`** — added `GetUserDefaultUILanguage` P/Invoke and `IsSystemChinese()` helper
- Replaced hardcoded English strings in `TrayIcon.cs`, `AppUpdater.cs`, `Program.cs`, `VirtualDesktopService.cs`

## Design decisions
- **No .resx / ResourceManager** — incompatible with Native AOT and adds unnecessary complexity for two languages
- **`InvariantGlobalization` unchanged** — our approach uses only Win32 P/Invoke, not .NET globalization APIs
- **Brand name "PeekDesktop" untranslated** — proper product name
- **Technical exception messages kept in English** — for debugging value


🤖 Generated with [Claude Code](https://claude.com/claude-code)