### PR TITLE
Add resource-based localization foundation

### DIFF
--- a/src/PeekDesktop.InteropHarness/Program.cs
+++ b/src/PeekDesktop.InteropHarness/Program.cs
@@ -1,8 +1,10 @@
 using System.Diagnostics;
+using System.Globalization;
 using System.IO.Compression;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using PeekDesktop;
+using PeekDesktop.Resources;
 
 internal static class Program
 {
@@ -37,6 +39,7 @@ internal static class Program
         RunTest("WinHttp download to file", options, failures, WinHttpDownloadToFile);
         RunTest("Zip extraction round-trip", options, failures, ZipExtractionRoundTrip);
         RunTest("WinVerifyTrust state cleanup", options, failures, WinVerifyTrustStateCleanup);
+        RunTest("Localization resource lookup", options, failures, LocalizationResourceLookup);
 
         if (failures.Count == 0)
         {
@@ -111,6 +114,31 @@ internal static class Program
         bool hasAccessibleDetails = NativeMethods.TryGetAccessibleDetailsAtPoint(point, out int role, out string name);
         if (hasAccessibleDetails || role != 0 || name.Length != 0)
             throw new InvalidOperationException("Accessible details baseline contract was violated.");
+    }
+
+    private static void LocalizationResourceLookup()
+    {
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo originalUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+            if (!string.Equals(Strings.Enabled, "Enabled", StringComparison.Ordinal))
+                throw new InvalidOperationException("Neutral English resource fallback failed.");
+
+            CultureInfo zhHans = CultureInfo.GetCultureInfo("zh-Hans");
+            CultureInfo.CurrentCulture = zhHans;
+            CultureInfo.CurrentUICulture = zhHans;
+            if (!string.Equals(Strings.Enabled, "启用", StringComparison.Ordinal))
+                throw new InvalidOperationException("Simplified Chinese resource lookup failed.");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
     }
 
     private static void InvalidHandleMatrix()

--- a/src/PeekDesktop/AppUpdater.cs
+++ b/src/PeekDesktop/AppUpdater.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using PeekDesktop.Resources;
 
 namespace PeekDesktop;
 
@@ -47,8 +48,8 @@ internal sealed class AppUpdater
             {
                 NativeMethods.MessageBoxW(
                     IntPtr.Zero,
-                    "PeekDesktop is already checking for updates.",
-                    "PeekDesktop Update",
+                    Strings.UpdateAlreadyCheckingMessage,
+                    Strings.UpdateMenuCaption,
                     NativeMethods.MB_OK | NativeMethods.MB_ICONINFORMATION);
             }
 
@@ -76,8 +77,8 @@ internal sealed class AppUpdater
                 {
                     NativeMethods.MessageBoxW(
                         IntPtr.Zero,
-                        $"You're already on the latest version of PeekDesktop ({currentVersion}).",
-                        "PeekDesktop Update",
+                        Strings.UpdateAlreadyLatestMessage(currentVersion),
+                        Strings.UpdateMenuCaption,
                         NativeMethods.MB_OK | NativeMethods.MB_ICONINFORMATION);
                 }
 
@@ -101,8 +102,8 @@ internal sealed class AppUpdater
             {
                 NativeMethods.MessageBoxW(
                     IntPtr.Zero,
-                    $"PeekDesktop couldn't check for updates.\n\n{ex.Message}",
-                    "Update Error",
+                    Strings.UpdateCheckFailedMessage(ex.Message),
+                    Strings.UpdateCheckErrorCaption,
                     NativeMethods.MB_OK | NativeMethods.MB_ICONERROR);
             }
         }
@@ -121,12 +122,12 @@ internal sealed class AppUpdater
         if (Interlocked.CompareExchange(ref _isUpdating, 1, 0) != 0)
             return;
 
-        latestVersion ??= _latestRelease is not null ? NormalizeVersion(_latestRelease.TagName) : "new version";
+        latestVersion ??= _latestRelease is not null ? NormalizeVersion(_latestRelease.TagName) : Strings.UpdateNewVersion;
 
         int result = NativeMethods.MessageBoxW(
             IntPtr.Zero,
-            $"PeekDesktop {latestVersion} is available.\n\nDownload and install it now? PeekDesktop will restart automatically.",
-            "Update Available",
+            Strings.UpdateAvailablePromptMessage(latestVersion),
+            Strings.UpdateAvailableCaption,
             NativeMethods.MB_YESNO | NativeMethods.MB_ICONINFORMATION);
 
         if (result != NativeMethods.IDYES)
@@ -226,9 +227,8 @@ internal sealed class AppUpdater
                 {
                     NativeMethods.MessageBoxW(
                         IntPtr.Zero,
-                        "The update was installed but PeekDesktop could not restart automatically.\n\n" +
-                        "Please start PeekDesktop manually.",
-                        "Update Installed",
+                        Strings.UpdateInstalledRestartFailedMessage(),
+                        Strings.UpdateInstalledCaption,
                         NativeMethods.MB_OK | NativeMethods.MB_ICONINFORMATION);
                     return;
                 }
@@ -269,8 +269,8 @@ internal sealed class AppUpdater
 
             NativeMethods.MessageBoxW(
                 IntPtr.Zero,
-                $"PeekDesktop couldn't install the update.\n\n{ex.Message}",
-                "Update Error",
+                Strings.UpdateInstallFailedMessage(ex.Message),
+                Strings.UpdateCheckErrorCaption,
                 NativeMethods.MB_OK | NativeMethods.MB_ICONERROR);
         }
         finally

--- a/src/PeekDesktop/PeekDesktop.csproj
+++ b/src/PeekDesktop/PeekDesktop.csproj
@@ -15,7 +15,7 @@
     <PublishAot>true</PublishAot>
     <OptimizationPreference>Size</OptimizationPreference>
     <!-- Aggressive size reduction -->
-    <InvariantGlobalization>true</InvariantGlobalization>
+    <InvariantGlobalization>false</InvariantGlobalization>
     <StackTraceSupport>false</StackTraceSupport>
     <UseSystemResourceKeys>true</UseSystemResourceKeys>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/PeekDesktop/Program.cs
+++ b/src/PeekDesktop/Program.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using PeekDesktop.Resources;
 
 namespace PeekDesktop;
 
@@ -67,7 +68,7 @@ public static class Program
                 }
                 catch (Exception ex)
                 {
-                    HandleFatalStartupError("Deferred initialization failed", ex);
+                    HandleFatalStartupError(Strings.StartupDeferredInitializationFailed, ex);
                     messageLoop.Quit();
                 }
             });
@@ -76,7 +77,7 @@ public static class Program
         }
         catch (Exception ex)
         {
-            HandleFatalStartupError("Program startup failed", ex);
+            HandleFatalStartupError(Strings.StartupProgramFailed, ex);
         }
         finally
         {
@@ -165,8 +166,8 @@ public static class Program
         AppDiagnostics.Log($"{context}: {ex}");
         NativeMethods.MessageBoxW(
             IntPtr.Zero,
-            $"{context}\n\n{ex.Message}",
-            "PeekDesktop failed to start",
+            Strings.StartupErrorMessage(context, ex.Message),
+            Strings.StartupErrorCaption,
             NativeMethods.MB_OK | NativeMethods.MB_ICONERROR);
     }
 }

--- a/src/PeekDesktop/Resources/Strings.cs
+++ b/src/PeekDesktop/Resources/Strings.cs
@@ -1,0 +1,62 @@
+using System.Globalization;
+using System.Resources;
+
+namespace PeekDesktop.Resources;
+
+internal static class Strings
+{
+    private static readonly ResourceManager ResourceManager = new("PeekDesktop.Resources.Strings", typeof(Strings).Assembly);
+
+    internal static string AboutCaption => GetString(nameof(AboutCaption));
+    internal static string AboutMessage => GetString(nameof(AboutMessage));
+    internal static string AutoCheckForUpdates => GetString(nameof(AutoCheckForUpdates));
+    internal static string CheckForUpdates => GetString(nameof(CheckForUpdates));
+    internal static string ClassicMinimize => GetString(nameof(ClassicMinimize));
+    internal static string DevBuild => GetString(nameof(DevBuild));
+    internal static string Enabled => GetString(nameof(Enabled));
+    internal static string Exit => GetString(nameof(Exit));
+    internal static string FlyAway => GetString(nameof(FlyAway));
+    internal static string FlyAwayExperimental => GetString(nameof(FlyAwayExperimental));
+    internal static string NativeShowDesktop => GetString(nameof(NativeShowDesktop));
+    internal static string PauseWhileGamingFullscreen => GetString(nameof(PauseWhileGamingFullscreen));
+    internal static string Peek => GetString(nameof(Peek));
+    internal static string PeekOnDesktopClick => GetString(nameof(PeekOnDesktopClick));
+    internal static string PeekOnTaskbarClick => GetString(nameof(PeekOnTaskbarClick));
+    internal static string RequireDoubleClick => GetString(nameof(RequireDoubleClick));
+    internal static string RestoreAllWindowsOnAppSwitch => GetString(nameof(RestoreAllWindowsOnAppSwitch));
+    internal static string ShowDesktopExplorer => GetString(nameof(ShowDesktopExplorer));
+    internal static string StartWithWindows => GetString(nameof(StartWithWindows));
+    internal static string StartupDeferredInitializationFailed => GetString(nameof(StartupDeferredInitializationFailed));
+    internal static string StartupProgramFailed => GetString(nameof(StartupProgramFailed));
+    internal static string StartupErrorCaption => GetString(nameof(StartupErrorCaption));
+    internal static string Tooltip => GetString(nameof(Tooltip));
+    internal static string UnknownVersion => GetString(nameof(UnknownVersion));
+    internal static string UpdateAlreadyCheckingMessage => GetString(nameof(UpdateAlreadyCheckingMessage));
+    internal static string UpdateAvailableCaption => GetString(nameof(UpdateAvailableCaption));
+    internal static string UpdateAvailableBalloonTitle => GetString(nameof(UpdateAvailableBalloonTitle));
+    internal static string UpdateCheckErrorCaption => GetString(nameof(UpdateCheckErrorCaption));
+    internal static string UpdateInstalledCaption => GetString(nameof(UpdateInstalledCaption));
+    internal static string UpdateMenuCaption => GetString(nameof(UpdateMenuCaption));
+    internal static string UpdateNewVersion => GetString(nameof(UpdateNewVersion));
+
+    internal static string AboutMessageFormat(string version) => Format(nameof(AboutMessage), version);
+    internal static string StartupErrorMessage(string context, string errorMessage) => Format(nameof(StartupErrorMessage), context, errorMessage);
+    internal static string TooltipFormat(string mode) => Format(nameof(Tooltip), mode);
+    internal static string UpdateAlreadyLatestMessage(string currentVersion) => Format(nameof(UpdateAlreadyLatestMessage), currentVersion);
+    internal static string UpdateAvailableBalloonText(string version) => Format(nameof(UpdateAvailableBalloonText), version);
+    internal static string UpdateAvailablePromptMessage(string version) => Format(nameof(UpdateAvailablePromptMessage), version);
+    internal static string UpdateCheckFailedMessage(string errorMessage) => Format(nameof(UpdateCheckFailedMessage), errorMessage);
+    internal static string UpdateInstallFailedMessage(string errorMessage) => Format(nameof(UpdateInstallFailedMessage), errorMessage);
+    internal static string UpdateInstalledRestartFailedMessage() => GetString(nameof(UpdateInstalledRestartFailedMessage));
+
+    internal static string GetString(string name)
+    {
+        return ResourceManager.GetString(name, CultureInfo.CurrentUICulture)
+            ?? throw new MissingManifestResourceException($"Missing localized string resource: {name}");
+    }
+
+    private static string Format(string name, params object[] args)
+    {
+        return string.Format(CultureInfo.CurrentUICulture, GetString(name), args);
+    }
+}

--- a/src/PeekDesktop/Resources/Strings.resx
+++ b/src/PeekDesktop/Resources/Strings.resx
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AboutCaption" xml:space="preserve">
+    <value>About PeekDesktop</value>
+  </data>
+  <data name="AboutMessage" xml:space="preserve">
+    <value>PeekDesktop v{0}
+
+Click your desktop wallpaper to peek at your desktop,
+just like macOS Sonoma.
+
+Click any window or the taskbar to restore.
+Peek Style lets you switch between Explorer show desktop
+and fly-away mode.
+
+Updates come from GitHub Releases.
+
+github.com/shanselman/PeekDesktop</value>
+  </data>
+  <data name="AutoCheckForUpdates" xml:space="preserve">
+    <value>Auto-Check for Updates</value>
+  </data>
+  <data name="CheckForUpdates" xml:space="preserve">
+    <value>Check for Updates</value>
+  </data>
+  <data name="ClassicMinimize" xml:space="preserve">
+    <value>Classic Minimize</value>
+  </data>
+  <data name="DevBuild" xml:space="preserve">
+    <value>dev build</value>
+  </data>
+  <data name="Enabled" xml:space="preserve">
+    <value>Enabled</value>
+  </data>
+  <data name="Exit" xml:space="preserve">
+    <value>Exit</value>
+  </data>
+  <data name="FlyAway" xml:space="preserve">
+    <value>Fly Away</value>
+  </data>
+  <data name="FlyAwayExperimental" xml:space="preserve">
+    <value>Fly Away (Experimental)</value>
+  </data>
+  <data name="NativeShowDesktop" xml:space="preserve">
+    <value>Native Show Desktop</value>
+  </data>
+  <data name="PauseWhileGamingFullscreen" xml:space="preserve">
+    <value>Pause While Gaming / Full-Screen</value>
+  </data>
+  <data name="Peek" xml:space="preserve">
+    <value>Peek</value>
+  </data>
+  <data name="PeekOnDesktopClick" xml:space="preserve">
+    <value>Peek on Desktop Click</value>
+  </data>
+  <data name="PeekOnTaskbarClick" xml:space="preserve">
+    <value>Peek on Taskbar Click</value>
+  </data>
+  <data name="RequireDoubleClick" xml:space="preserve">
+    <value>Require Double-Click</value>
+  </data>
+  <data name="RestoreAllWindowsOnAppSwitch" xml:space="preserve">
+    <value>Restore All Windows on App Switch</value>
+  </data>
+  <data name="ShowDesktopExplorer" xml:space="preserve">
+    <value>Show Desktop (Explorer)</value>
+  </data>
+  <data name="StartWithWindows" xml:space="preserve">
+    <value>Start with Windows</value>
+  </data>
+  <data name="StartupDeferredInitializationFailed" xml:space="preserve">
+    <value>Deferred initialization failed</value>
+  </data>
+  <data name="StartupErrorCaption" xml:space="preserve">
+    <value>PeekDesktop failed to start</value>
+  </data>
+  <data name="StartupErrorMessage" xml:space="preserve">
+    <value>{0}
+
+{1}</value>
+  </data>
+  <data name="StartupProgramFailed" xml:space="preserve">
+    <value>Program startup failed</value>
+  </data>
+  <data name="Tooltip" xml:space="preserve">
+    <value>PeekDesktop - {0}</value>
+  </data>
+  <data name="UnknownVersion" xml:space="preserve">
+    <value>unknown</value>
+  </data>
+  <data name="UpdateAlreadyCheckingMessage" xml:space="preserve">
+    <value>PeekDesktop is already checking for updates.</value>
+  </data>
+  <data name="UpdateAlreadyLatestMessage" xml:space="preserve">
+    <value>You're already on the latest version of PeekDesktop ({0}).</value>
+  </data>
+  <data name="UpdateAvailableBalloonText" xml:space="preserve">
+    <value>Version {0} is available. Click here to download and install.</value>
+  </data>
+  <data name="UpdateAvailableBalloonTitle" xml:space="preserve">
+    <value>PeekDesktop Update Available</value>
+  </data>
+  <data name="UpdateAvailableCaption" xml:space="preserve">
+    <value>Update Available</value>
+  </data>
+  <data name="UpdateAvailablePromptMessage" xml:space="preserve">
+    <value>PeekDesktop {0} is available.
+
+Download and install it now? PeekDesktop will restart automatically.</value>
+  </data>
+  <data name="UpdateCheckErrorCaption" xml:space="preserve">
+    <value>Update Error</value>
+  </data>
+  <data name="UpdateCheckFailedMessage" xml:space="preserve">
+    <value>PeekDesktop couldn't check for updates.
+
+{0}</value>
+  </data>
+  <data name="UpdateInstalledCaption" xml:space="preserve">
+    <value>Update Installed</value>
+  </data>
+  <data name="UpdateInstalledRestartFailedMessage" xml:space="preserve">
+    <value>The update was installed but PeekDesktop could not restart automatically.
+
+Please start PeekDesktop manually.</value>
+  </data>
+  <data name="UpdateInstallFailedMessage" xml:space="preserve">
+    <value>PeekDesktop couldn't install the update.
+
+{0}</value>
+  </data>
+  <data name="UpdateMenuCaption" xml:space="preserve">
+    <value>PeekDesktop Update</value>
+  </data>
+  <data name="UpdateNewVersion" xml:space="preserve">
+    <value>new version</value>
+  </data>
+</root>

--- a/src/PeekDesktop/Resources/Strings.zh-Hans.resx
+++ b/src/PeekDesktop/Resources/Strings.zh-Hans.resx
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AboutCaption" xml:space="preserve">
+    <value>关于 PeekDesktop</value>
+  </data>
+  <data name="AboutMessage" xml:space="preserve">
+    <value>PeekDesktop v{0}
+
+点击桌面壁纸即可预览桌面，
+就像 macOS Sonoma 一样。
+
+点击任意窗口或任务栏即可恢复。
+“预览样式”可在资源管理器显示桌面
+和飞离模式之间切换。
+
+更新来自 GitHub Releases。
+
+github.com/shanselman/PeekDesktop</value>
+  </data>
+  <data name="AutoCheckForUpdates" xml:space="preserve">
+    <value>自动检查更新</value>
+  </data>
+  <data name="CheckForUpdates" xml:space="preserve">
+    <value>检查更新</value>
+  </data>
+  <data name="ClassicMinimize" xml:space="preserve">
+    <value>经典最小化</value>
+  </data>
+  <data name="DevBuild" xml:space="preserve">
+    <value>开发版本</value>
+  </data>
+  <data name="Enabled" xml:space="preserve">
+    <value>启用</value>
+  </data>
+  <data name="Exit" xml:space="preserve">
+    <value>退出</value>
+  </data>
+  <data name="FlyAway" xml:space="preserve">
+    <value>飞离</value>
+  </data>
+  <data name="FlyAwayExperimental" xml:space="preserve">
+    <value>飞离（实验）</value>
+  </data>
+  <data name="NativeShowDesktop" xml:space="preserve">
+    <value>原生显示桌面</value>
+  </data>
+  <data name="PauseWhileGamingFullscreen" xml:space="preserve">
+    <value>游戏/全屏时暂停</value>
+  </data>
+  <data name="Peek" xml:space="preserve">
+    <value>预览</value>
+  </data>
+  <data name="PeekOnDesktopClick" xml:space="preserve">
+    <value>点击桌面时预览</value>
+  </data>
+  <data name="PeekOnTaskbarClick" xml:space="preserve">
+    <value>点击任务栏时预览</value>
+  </data>
+  <data name="RequireDoubleClick" xml:space="preserve">
+    <value>需要双击</value>
+  </data>
+  <data name="RestoreAllWindowsOnAppSwitch" xml:space="preserve">
+    <value>切换应用时恢复所有窗口</value>
+  </data>
+  <data name="ShowDesktopExplorer" xml:space="preserve">
+    <value>显示桌面（资源管理器）</value>
+  </data>
+  <data name="StartWithWindows" xml:space="preserve">
+    <value>随 Windows 启动</value>
+  </data>
+  <data name="StartupDeferredInitializationFailed" xml:space="preserve">
+    <value>延迟初始化失败</value>
+  </data>
+  <data name="StartupErrorCaption" xml:space="preserve">
+    <value>PeekDesktop 启动失败</value>
+  </data>
+  <data name="StartupErrorMessage" xml:space="preserve">
+    <value>{0}
+
+{1}</value>
+  </data>
+  <data name="StartupProgramFailed" xml:space="preserve">
+    <value>程序启动失败</value>
+  </data>
+  <data name="Tooltip" xml:space="preserve">
+    <value>PeekDesktop - {0}</value>
+  </data>
+  <data name="UnknownVersion" xml:space="preserve">
+    <value>未知</value>
+  </data>
+  <data name="UpdateAlreadyCheckingMessage" xml:space="preserve">
+    <value>PeekDesktop 正在检查更新。</value>
+  </data>
+  <data name="UpdateAlreadyLatestMessage" xml:space="preserve">
+    <value>你已经在使用 PeekDesktop 的最新版本（{0}）。</value>
+  </data>
+  <data name="UpdateAvailableBalloonText" xml:space="preserve">
+    <value>版本 {0} 可用。点击此处下载并安装。</value>
+  </data>
+  <data name="UpdateAvailableBalloonTitle" xml:space="preserve">
+    <value>PeekDesktop 有可用更新</value>
+  </data>
+  <data name="UpdateAvailableCaption" xml:space="preserve">
+    <value>有可用更新</value>
+  </data>
+  <data name="UpdateAvailablePromptMessage" xml:space="preserve">
+    <value>PeekDesktop {0} 可用。
+
+现在下载并安装吗？PeekDesktop 将自动重启。</value>
+  </data>
+  <data name="UpdateCheckErrorCaption" xml:space="preserve">
+    <value>更新错误</value>
+  </data>
+  <data name="UpdateCheckFailedMessage" xml:space="preserve">
+    <value>PeekDesktop 无法检查更新。
+
+{0}</value>
+  </data>
+  <data name="UpdateInstalledCaption" xml:space="preserve">
+    <value>更新已安装</value>
+  </data>
+  <data name="UpdateInstalledRestartFailedMessage" xml:space="preserve">
+    <value>更新已安装，但 PeekDesktop 无法自动重启。
+
+请手动启动 PeekDesktop。</value>
+  </data>
+  <data name="UpdateInstallFailedMessage" xml:space="preserve">
+    <value>PeekDesktop 无法安装更新。
+
+{0}</value>
+  </data>
+  <data name="UpdateMenuCaption" xml:space="preserve">
+    <value>PeekDesktop 更新</value>
+  </data>
+  <data name="UpdateNewVersion" xml:space="preserve">
+    <value>新版本</value>
+  </data>
+</root>

--- a/src/PeekDesktop/TrayIcon.cs
+++ b/src/PeekDesktop/TrayIcon.cs
@@ -1,4 +1,5 @@
 using System;
+using PeekDesktop.Resources;
 
 namespace PeekDesktop;
 
@@ -50,8 +51,8 @@ internal sealed class TrayIcon : IDisposable
         _appUpdater.UpdateAvailable += (_, e) =>
         {
             _trayIcon.ShowBalloon(
-                "PeekDesktop Update Available",
-                $"Version {e.Version} is available. Click here to download and install.");
+                Strings.UpdateAvailableBalloonTitle,
+                Strings.UpdateAvailableBalloonText(e.Version));
         };
 
         // Let the updater remove the tray icon before exiting during update
@@ -101,22 +102,22 @@ internal sealed class TrayIcon : IDisposable
     {
         using var menu = new Win32Menu();
 
-        menu.AddItem(ID_ENABLED, "Enabled", ToggleEnabled, _settings.Enabled);
-        menu.AddItem(ID_STARTUP, "Start with Windows", ToggleStartup, _settings.StartWithWindows);
-        menu.AddItem(ID_DOUBLECLICK, "Require Double-Click", ToggleDoubleClick, _settings.RequireDoubleClick);
-        menu.AddItem(ID_DESKTOP_CLICK, "Peek on Desktop Click", ToggleDesktopClick, _settings.PeekOnDesktopClick);
-        menu.AddItem(ID_TASKBAR_CLICK, "Peek on Taskbar Click", ToggleTaskbarClick, _settings.PeekOnTaskbarClick);
-        menu.AddItem(ID_RESTORE_ON_APP_OPEN, "Restore All Windows on App Switch", ToggleRestoreOnAppOpen, _settings.RestoreHiddenWindowsOnAppOpen);
-        menu.AddItem(ID_GAME_GUARD, "Pause While Gaming / Full-Screen", ToggleGameGuard, _settings.PauseWhileFullscreenAppActive);
+        menu.AddItem(ID_ENABLED, Strings.Enabled, ToggleEnabled, _settings.Enabled);
+        menu.AddItem(ID_STARTUP, Strings.StartWithWindows, ToggleStartup, _settings.StartWithWindows);
+        menu.AddItem(ID_DOUBLECLICK, Strings.RequireDoubleClick, ToggleDoubleClick, _settings.RequireDoubleClick);
+        menu.AddItem(ID_DESKTOP_CLICK, Strings.PeekOnDesktopClick, ToggleDesktopClick, _settings.PeekOnDesktopClick);
+        menu.AddItem(ID_TASKBAR_CLICK, Strings.PeekOnTaskbarClick, ToggleTaskbarClick, _settings.PeekOnTaskbarClick);
+        menu.AddItem(ID_RESTORE_ON_APP_OPEN, Strings.RestoreAllWindowsOnAppSwitch, ToggleRestoreOnAppOpen, _settings.RestoreHiddenWindowsOnAppOpen);
+        menu.AddItem(ID_GAME_GUARD, Strings.PauseWhileGamingFullscreen, ToggleGameGuard, _settings.PauseWhileFullscreenAppActive);
         menu.AddSeparator();
-        menu.AddItem(ID_MODE_NATIVE, "Show Desktop (Explorer)", () => SetPeekMode(PeekMode.NativeShowDesktop), _settings.PeekMode == PeekMode.NativeShowDesktop);
-        menu.AddItem(ID_MODE_FLYAWAY, "Fly Away (Experimental)", () => SetPeekMode(PeekMode.FlyAway), _settings.PeekMode == PeekMode.FlyAway);
+        menu.AddItem(ID_MODE_NATIVE, Strings.ShowDesktopExplorer, () => SetPeekMode(PeekMode.NativeShowDesktop), _settings.PeekMode == PeekMode.NativeShowDesktop);
+        menu.AddItem(ID_MODE_FLYAWAY, Strings.FlyAwayExperimental, () => SetPeekMode(PeekMode.FlyAway), _settings.PeekMode == PeekMode.FlyAway);
         menu.AddSeparator();
-        menu.AddItem(ID_ABOUT, "About PeekDesktop", ShowAbout);
-        menu.AddItem(ID_UPDATES, "Check for Updates", CheckForUpdates);
-        menu.AddItem(ID_AUTO_UPDATES, "Auto-Check for Updates", ToggleAutoUpdates, _settings.AutoCheckForUpdates);
+        menu.AddItem(ID_ABOUT, Strings.AboutCaption, ShowAbout);
+        menu.AddItem(ID_UPDATES, Strings.CheckForUpdates, CheckForUpdates);
+        menu.AddItem(ID_AUTO_UPDATES, Strings.AutoCheckForUpdates, ToggleAutoUpdates, _settings.AutoCheckForUpdates);
         menu.AddSeparator();
-        menu.AddItem(ID_EXIT, "Exit", DoExit);
+        menu.AddItem(ID_EXIT, Strings.Exit, DoExit);
 
         menu.Show(_messageLoop.Handle);
     }
@@ -180,7 +181,7 @@ internal sealed class TrayIcon : IDisposable
     {
         _settings.PeekMode = peekMode;
         _desktopPeek.SetPeekMode(peekMode);
-        _trayIcon.UpdateTooltip($"PeekDesktop - {GetPeekModeDisplayName(peekMode)}");
+        _trayIcon.UpdateTooltip(Strings.TooltipFormat(GetPeekModeDisplayName(peekMode)));
         _settings.Save();
     }
 
@@ -189,15 +190,8 @@ internal sealed class TrayIcon : IDisposable
         string version = GetDisplayVersion();
         NativeMethods.MessageBoxW(
             IntPtr.Zero,
-            $"PeekDesktop v{version}\n\n" +
-            "Click your desktop wallpaper to peek at your desktop,\n" +
-            "just like macOS Sonoma.\n\n" +
-            "Click any window or the taskbar to restore.\n" +
-            "Peek Style lets you switch between Explorer show desktop\n" +
-            "and fly-away mode.\n\n" +
-            "Updates come from GitHub Releases.\n\n" +
-            "github.com/shanselman/PeekDesktop",
-            "About PeekDesktop",
+            Strings.AboutMessageFormat(version),
+            Strings.AboutCaption,
             NativeMethods.MB_OK | NativeMethods.MB_ICONINFORMATION);
     }
 
@@ -224,7 +218,7 @@ internal sealed class TrayIcon : IDisposable
         string? version = productVersion ?? fileVersion?.ToString();
 
         if (string.IsNullOrWhiteSpace(version))
-            return "unknown";
+            return Strings.UnknownVersion;
 
         int plusIndex = version.IndexOf('+');
         version = plusIndex >= 0 ? version[..plusIndex] : version;
@@ -234,8 +228,8 @@ internal sealed class TrayIcon : IDisposable
 
         return version switch
         {
-            "1.0.0.0" => "dev build",
-            "1.0.0" => "dev build",
+            "1.0.0.0" => Strings.DevBuild,
+            "1.0.0" => Strings.DevBuild,
             _ => version
         };
     }
@@ -244,10 +238,10 @@ internal sealed class TrayIcon : IDisposable
     {
         return peekMode switch
         {
-            PeekMode.Minimize => "Classic Minimize",
-            PeekMode.FlyAway => "Fly Away",
-            PeekMode.NativeShowDesktop => "Native Show Desktop",
-            _ => "Peek"
+            PeekMode.Minimize => Strings.ClassicMinimize,
+            PeekMode.FlyAway => Strings.FlyAway,
+            PeekMode.NativeShowDesktop => Strings.NativeShowDesktop,
+            _ => Strings.Peek
         };
     }
 


### PR DESCRIPTION
## Summary
- Add neutral English and `zh-Hans` resource files for current user-facing UI strings
- Route tray menu, About dialog, update prompts, balloon text, startup errors, and tooltip text through a central `Strings` helper
- Disable invariant globalization so culture-aware resource lookup works, including NativeAOT publish output
- Add an interop harness smoke test for English fallback and Simplified Chinese lookup

## Validation
- `dotnet build .\PeekDesktop.sln --nologo`
- `dotnet run --project .\src\PeekDesktop.InteropHarness\PeekDesktop.InteropHarness.csproj -- 1000`
- `dotnet publish .\src\PeekDesktop\PeekDesktop.csproj -c Release -r win-x64 --self-contained true --nologo`

## Manual follow-up
Scott should spot-check the tray menu, About dialog, update prompts, and tray tooltip under English and Simplified Chinese UI culture before release.