### PR TITLE
Fix unrelated double-click handling

### DIFF
--- a/Docs/PeekDesktop-Engineering-Deep-Dive.md
+++ b/Docs/PeekDesktop-Engineering-Deep-Dive.md
@@ -33,15 +33,15 @@ That framing matters. A mode that is flashy but occasionally restores incorrectl
 
 ## 2. High-level architecture and important files
 
-PeekDesktop is a .NET 10 WinForms tray application with a very small but well-factored architecture.
+PeekDesktop is a .NET 10 native Win32 tray application with a very small but well-factored architecture.
 
 ### Main runtime pieces
 
 | File | Responsibility | Notes |
 |---|---|---|
-| `src\PeekDesktop\Program.cs` | Entry point and single-instance mutex | Starts a tray-only `ApplicationContext` and defers init until the message loop is ready |
+| `src\PeekDesktop\Program.cs` | Entry point and single-instance mutex | Starts the native `Win32MessageLoop` and defers init until it is pumping |
 | `src\PeekDesktop\DesktopPeek.cs` | Core state machine | Orchestrates Idle <-> Peeking transitions and chooses the active peek implementation |
-| `src\PeekDesktop\MouseHook.cs` | Global mouse detection | Uses `WH_MOUSE_LL` to catch left-clicks and classify them |
+| `src\PeekDesktop\MouseHook.cs` | Explorer-surface mouse detection | Uses `WH_MOUSE_LL`, but only tracks configured desktop/taskbar surfaces |
 | `src\PeekDesktop\DesktopDetector.cs` | Desktop/background/icon discrimination | Differentiates wallpaper clicks from icon clicks |
 | `src\PeekDesktop\FocusWatcher.cs` | Foreground-window monitoring | Uses `SetWinEventHook(EVENT_SYSTEM_FOREGROUND)` to know when to restore |
 | `src\PeekDesktop\WindowTracker.cs` | Classic capture/minimize/restore pipeline | Tracks window placement, filters bad candidates, restores Z-order |
@@ -69,12 +69,13 @@ This is the heart of the project. The reliability of the UX depends on correctly
 `MouseHook.cs` installs a global low-level hook using the official Win32 API:
 
 - `SetWindowsHookEx(WH_MOUSE_LL)`
-- capture `WM_LBUTTONDOWN`
+- observe `WM_LBUTTONDOWN`, `WM_MOUSEMOVE`, and `WM_LBUTTONUP`
 - call `WindowFromPoint` to get the window under the cursor
+- immediately pass through clicks outside enabled Explorer desktop/taskbar surfaces
 
-A subtle but important implementation detail: the hook callback posts heavier work back to the UI thread via `SynchronizationContext`.
+A subtle but important implementation detail: the hook callback posts heavier work back to the application thread via `Win32MessageLoop.BeginInvoke`.
 
-That is exactly the right design. Low-level hooks must return quickly or Windows may unhook them or make the system feel sluggish. PeekDesktop only captures the point and target window in the hook, then does the classification work later.
+Low-level hooks must return quickly or Windows may unhook them or make the system feel sluggish. PeekDesktop only performs lightweight surface gating and click-sequence tracking in the hook. Explorer-specific hierarchy, list-view, MSAA, and UI Automation classification runs after the hook has returned. Non-Explorer clicks do not create pending state or classification callbacks.
 
 ### Step 2: classify the click target
 
@@ -82,22 +83,32 @@ That is exactly the right design. Low-level hooks must return quickly or Windows
 
 - `DesktopBackground`
 - `DesktopIcon`
+- `TaskbarBackground`
 - `NonDesktop`
 
 It does this in layers:
 
-1. **Desktop ancestry check**
+1. **Configured Explorer surface check**
+   - Verify that the target belongs to `explorer.exe`.
+   - Reject desktop or taskbar surfaces when their corresponding trigger is disabled.
+   - Ignore ordinary Explorer windows that are not part of the desktop or taskbar.
+
+2. **Desktop ancestry check**
    - Walk up the parent chain looking for:
      - `Progman`
      - `WorkerW` that actually hosts `SHELLDLL_DefView`
    - This avoids treating unrelated `WorkerW` shell helper windows as the real desktop.
 
-2. **List-view hit test for icons**
+3. **List-view hit test for icons**
    - If the click is over `SysListView32`, the code performs a real list-view hit test to determine whether the pointer landed on an icon item or just empty desktop area.
 
-3. **MSAA accessibility fallback**
+4. **MSAA accessibility fallback**
    - `AccessibleObjectFromPoint` is used as a fallback to inspect the accessibility role at the click point.
    - If the role is `ROLE_SYSTEM_LISTITEM`, the click is treated as an icon click.
+
+5. **Taskbar blank-area check**
+   - Known taskbar ancestry is checked first.
+   - Windows 11 composition overlays fall back to UI Automation so buttons remain interactive while truly blank space can trigger peek.
 
 This two-layer icon detection is important. `WindowFromPoint` alone is not enough because the desktop surface and the icon list view overlap conceptually.
 
@@ -107,7 +118,7 @@ This two-layer icon detection is important. `WindowFromPoint` alone is not enoug
 
 ```text
 Idle -> Peeking   when empty wallpaper is clicked
-Peeking -> Idle   when a non-desktop window is activated or clicked
+Peeking -> Idle   when a non-desktop window is activated
 ```
 
 Key fields:

--- a/src/PeekDesktop.InteropHarness/Program.cs
+++ b/src/PeekDesktop.InteropHarness/Program.cs
@@ -27,6 +27,7 @@ internal static class Program
         RunTest("Version info smoke", options, failures, VersionInfoSmoke);
         RunTest("Notification state stress", options, failures, NotificationStateStress);
         RunTest("Malformed input contracts", options, failures, MalformedInputContracts);
+        RunTest("Mouse click routing logic", options, failures, MouseClickRoutingLogic);
         RunTest($"Leak probe ({options.Iterations:N0} iterations)", options, failures, () => LeakProbe(options));
 
         // Auto-updater tests
@@ -111,6 +112,190 @@ internal static class Program
         bool hasAccessibleDetails = NativeMethods.TryGetAccessibleDetailsAtPoint(point, out int role, out string name);
         if (hasAccessibleDetails || role != 0 || name.Length != 0)
             throw new InvalidOperationException("Accessible details baseline contract was violated.");
+    }
+
+    private static void MouseClickRoutingLogic()
+    {
+        const uint doubleClickTime = 500;
+        const int doubleClickDistance = 2;
+        const int dragDistance = 4;
+        var surfaceWindow = new IntPtr(101);
+        var otherSurfaceWindow = new IntPtr(202);
+        var origin = new NativeMethods.POINT { x = 100, y = 200 };
+        var nearby = new NativeMethods.POINT { x = 101, y = 201 };
+        var dragged = new NativeMethods.POINT { x = 110, y = 200 };
+        var tracker = new MouseClickTracker();
+
+        if (!tracker.TryBeginClick(
+                surfaceWindow,
+                origin,
+                requireDoubleClick: false,
+                tick: 1_000,
+                doubleClickTime,
+                doubleClickDistance,
+                doubleClickDistance)
+            || !tracker.TryCompleteClick(nearby, dragDistance, dragDistance, out PendingMouseClick singleClick)
+            || singleClick.Window != surfaceWindow
+            || singleClick.Point.x != origin.x
+            || singleClick.Point.y != origin.y)
+        {
+            throw new InvalidOperationException("Single-click mode did not preserve and complete the candidate click.");
+        }
+
+        tracker.Reset();
+        if (tracker.TryBeginClick(
+                surfaceWindow,
+                origin,
+                requireDoubleClick: true,
+                tick: 2_000,
+                doubleClickTime,
+                doubleClickDistance,
+                doubleClickDistance)
+            || tracker.HasPendingClick)
+        {
+            throw new InvalidOperationException("The first click incorrectly armed double-click activation.");
+        }
+
+        if (!tracker.TryBeginClick(
+                surfaceWindow,
+                nearby,
+                requireDoubleClick: true,
+                tick: 2_200,
+                doubleClickTime,
+                doubleClickDistance,
+                doubleClickDistance)
+            || !tracker.TryCompleteClick(nearby, dragDistance, dragDistance, out _))
+        {
+            throw new InvalidOperationException("A valid second click did not complete double-click activation.");
+        }
+
+        tracker.Reset();
+        _ = tracker.TryBeginClick(
+            surfaceWindow,
+            origin,
+            requireDoubleClick: true,
+            tick: 3_000,
+            doubleClickTime,
+            doubleClickDistance,
+            doubleClickDistance);
+        if (tracker.TryBeginClick(
+                otherSurfaceWindow,
+                origin,
+                requireDoubleClick: true,
+                tick: 3_100,
+                doubleClickTime,
+                doubleClickDistance,
+                doubleClickDistance))
+        {
+            throw new InvalidOperationException("Clicks on different Explorer surfaces were combined into a double-click.");
+        }
+
+        tracker.Reset();
+        _ = tracker.TryBeginClick(
+            surfaceWindow,
+            origin,
+            requireDoubleClick: true,
+            tick: 3_500,
+            doubleClickTime,
+            doubleClickDistance,
+            doubleClickDistance);
+        if (tracker.TryBeginClick(
+                surfaceWindow,
+                nearby,
+                requireDoubleClick: true,
+                tick: 4_001,
+                doubleClickTime,
+                doubleClickDistance,
+                doubleClickDistance))
+        {
+            throw new InvalidOperationException("Clicks outside the system time window were combined into a double-click.");
+        }
+
+        tracker.Reset();
+        _ = tracker.TryBeginClick(
+            surfaceWindow,
+            origin,
+            requireDoubleClick: true,
+            tick: 4_000,
+            doubleClickTime,
+            doubleClickDistance,
+            doubleClickDistance);
+        tracker.Reset();
+        if (tracker.TryBeginClick(
+                surfaceWindow,
+                nearby,
+                requireDoubleClick: true,
+                tick: 4_100,
+                doubleClickTime,
+                doubleClickDistance,
+                doubleClickDistance))
+        {
+            throw new InvalidOperationException("A reset click sequence incorrectly completed a double-click.");
+        }
+
+        tracker.Reset();
+        _ = tracker.TryBeginClick(
+            surfaceWindow,
+            origin,
+            requireDoubleClick: false,
+            tick: 5_000,
+            doubleClickTime,
+            doubleClickDistance,
+            doubleClickDistance);
+        if (!tracker.CancelIfMoved(dragged, dragDistance, dragDistance)
+            || tracker.TryCompleteClick(dragged, dragDistance, dragDistance, out _))
+        {
+            throw new InvalidOperationException("Drag movement did not cancel the pending click.");
+        }
+
+        if (DesktopDetector.IsPotentialPeekSurfaceWindow(
+            IntPtr.Zero,
+            origin,
+            includeDesktop: true,
+            includeTaskbar: true))
+        {
+            throw new InvalidOperationException("A zero window was accepted as an Explorer click surface.");
+        }
+
+        IntPtr taskbarWindow = NativeMethods.FindWindow("Shell_TrayWnd", null);
+        if (taskbarWindow != IntPtr.Zero)
+        {
+            if (!DesktopDetector.IsPotentialPeekSurfaceWindow(
+                    taskbarWindow,
+                    origin,
+                    includeDesktop: false,
+                    includeTaskbar: true)
+                || DesktopDetector.IsPotentialPeekSurfaceWindow(
+                    taskbarWindow,
+                    origin,
+                    includeDesktop: false,
+                    includeTaskbar: false))
+            {
+                throw new InvalidOperationException("Taskbar surface gating did not honor the configured trigger.");
+            }
+        }
+
+        IntPtr desktopWindow = NativeMethods.FindWindow("Progman", null);
+        if (desktopWindow != IntPtr.Zero
+            && (!DesktopDetector.IsPotentialPeekSurfaceWindow(
+                    desktopWindow,
+                    origin,
+                    includeDesktop: true,
+                    includeTaskbar: false)
+                || DesktopDetector.IsPotentialPeekSurfaceWindow(
+                    desktopWindow,
+                    origin,
+                    includeDesktop: false,
+                    includeTaskbar: false)))
+        {
+            throw new InvalidOperationException("Desktop surface gating did not honor the configured trigger.");
+        }
+
+        Action? queuedAction = null;
+        using var hook = new MouseHook(action => queuedAction = action);
+        hook.DispatchMouseClick(IntPtr.Zero, origin);
+        if (queuedAction is null)
+            throw new InvalidOperationException("Mouse classification was not deferred through the supplied dispatcher.");
     }
 
     private static void InvalidHandleMatrix()

--- a/src/PeekDesktop/DesktopDetector.cs
+++ b/src/PeekDesktop/DesktopDetector.cs
@@ -17,23 +17,25 @@ internal enum DesktopClickTarget
 public static class DesktopDetector
 {
     /// <summary>
-    /// When true, clicks on empty taskbar area also trigger desktop peek.
-    /// </summary>
-    public static bool PeekOnTaskbarClick { get; set; }
-
-    /// <summary>
     /// Classifies a click as hitting the desktop wallpaper, a desktop icon,
     /// or something unrelated to the desktop.
     /// </summary>
-    internal static DesktopClickTarget GetClickTarget(IntPtr hwnd, NativeMethods.POINT point)
+    internal static DesktopClickTarget GetClickTarget(
+        IntPtr hwnd,
+        NativeMethods.POINT point,
+        bool includeDesktop,
+        bool includeTaskbar)
     {
-        if (PeekOnTaskbarClick && IsTaskbarBlankAreaWindow(hwnd, point))
+        if (!IsPotentialPeekSurfaceWindow(hwnd, point, includeDesktop, includeTaskbar))
+            return DesktopClickTarget.NonDesktop;
+
+        if (includeTaskbar && IsTaskbarBlankAreaWindow(hwnd, point))
         {
             AppDiagnostics.Log("Taskbar blank-area click detected");
             return DesktopClickTarget.TaskbarBackground;
         }
 
-        if (PeekOnTaskbarClick && IsMonitorTaskbarAreaPoint(point))
+        if (includeTaskbar && IsMonitorTaskbarAreaPoint(point))
         {
             AppDiagnostics.Log($"Taskbar-area click detected without taskbar hwnd at {NativeMethods.DescribePoint(point)}; deferring to UIA");
             if (ClassifyTaskbarOverlayPoint(point))
@@ -43,14 +45,10 @@ public static class DesktopDetector
             }
         }
 
-        if (!IsDesktopRelatedWindow(hwnd))
+        if (!includeDesktop || !IsDesktopRelatedWindow(hwnd))
         {
             AppDiagnostics.Log($"Desktop relationship check failed at {NativeMethods.DescribePoint(point)}");
             AppDiagnostics.Log($"Desktop relationship reason: {GetDesktopRelationshipReason(hwnd)}");
-
-            if (NativeMethods.TryGetAccessibleDetailsAtPoint(point, out int role, out string name))
-                AppDiagnostics.Log($"Non-desktop accessibility probe: role=0x{role:X} name=\"{name}\"");
-
             return DesktopClickTarget.NonDesktop;
         }
 
@@ -71,6 +69,41 @@ public static class DesktopDetector
         }
 
         return DesktopClickTarget.DesktopBackground;
+    }
+
+    internal static bool IsPotentialPeekSurfaceWindow(
+        IntPtr hwnd,
+        NativeMethods.POINT point,
+        bool includeDesktop,
+        bool includeTaskbar)
+    {
+        if (hwnd == IntPtr.Zero)
+            return false;
+
+        bool isConfiguredSurface = (includeDesktop && IsDesktopRelatedWindow(hwnd))
+            || (includeTaskbar
+                && (IsTaskbarRelatedWindow(hwnd) || IsMonitorTaskbarAreaPoint(point)));
+
+        return isConfiguredSurface && IsExplorerOwnedWindow(hwnd);
+    }
+
+    private static bool IsExplorerOwnedWindow(IntPtr hwnd)
+    {
+        _ = NativeMethods.GetWindowThreadProcessId(hwnd, out uint processId);
+        if (processId == 0)
+            return false;
+
+        return WindowBelongsToProcess(NativeMethods.FindWindow("Progman", null), processId)
+            || WindowBelongsToProcess(NativeMethods.FindWindow("Shell_TrayWnd", null), processId);
+    }
+
+    private static bool WindowBelongsToProcess(IntPtr hwnd, uint processId)
+    {
+        if (hwnd == IntPtr.Zero)
+            return false;
+
+        _ = NativeMethods.GetWindowThreadProcessId(hwnd, out uint windowProcessId);
+        return windowProcessId == processId;
     }
 
     internal static string GetDesktopRelationshipReason(IntPtr hwnd)
@@ -167,6 +200,24 @@ public static class DesktopDetector
             string className = NativeMethods.GetWindowClassName(current);
             if (string.Equals(className, "SysListView32", StringComparison.OrdinalIgnoreCase))
                 return true;
+
+            current = NativeMethods.GetParent(current);
+        }
+
+        return false;
+    }
+
+    private static bool IsTaskbarRelatedWindow(IntPtr hwnd)
+    {
+        IntPtr current = hwnd;
+        while (current != IntPtr.Zero)
+        {
+            string className = NativeMethods.GetWindowClassName(current);
+            if (string.Equals(className, "Shell_TrayWnd", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(className, "Shell_SecondaryTrayWnd", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
 
             current = NativeMethods.GetParent(current);
         }

--- a/src/PeekDesktop/DesktopPeek.cs
+++ b/src/PeekDesktop/DesktopPeek.cs
@@ -25,7 +25,7 @@ public sealed class DesktopPeek : IDisposable
         "gamebarpresencewriter"
     };
 
-    private readonly MouseHook _mouseHook = new();
+    private readonly MouseHook _mouseHook;
     private readonly FocusWatcher _focusWatcher = new();
     private readonly WindowTracker _windowTracker = new();
     private readonly List<IntPtr> _deferredTeamsRestoreHandles = new();
@@ -46,18 +46,21 @@ public sealed class DesktopPeek : IDisposable
     public bool IsPeeking => _isPeeking;
     public PeekMode PeekMode { get; set; }
 
-    public DesktopPeek(Settings settings)
+    public DesktopPeek(Settings settings, Action<Action> beginInvoke)
     {
+        _mouseHook = new MouseHook(beginInvoke)
+        {
+            RequireDoubleClick = settings.RequireDoubleClick,
+            MonitorDesktopClicks = settings.PeekOnDesktopClick,
+            MonitorTaskbarClicks = settings.PeekOnTaskbarClick
+        };
         PeekMode = NormalizePeekMode(settings.PeekMode);
-        _mouseHook.RequireDoubleClick = settings.RequireDoubleClick;
         _pauseWhileFullscreenAppActive = settings.PauseWhileFullscreenAppActive;
         _restoreHiddenWindowsOnAppOpen = settings.RestoreHiddenWindowsOnAppOpen;
         _peekOnDesktopClick = settings.PeekOnDesktopClick;
-        DesktopDetector.PeekOnTaskbarClick = settings.PeekOnTaskbarClick;
         AppDiagnostics.Log("DesktopPeek created");
         _mouseHook.DesktopClicked += OnDesktopClicked;
         _mouseHook.DesktopIconClicked += OnDesktopIconClicked;
-        _mouseHook.NonDesktopClicked += OnNonDesktopClicked;
         _mouseHook.TaskbarClicked += OnTaskbarClicked;
         _focusWatcher.FocusChanged += OnFocusChanged;
     }
@@ -70,13 +73,14 @@ public sealed class DesktopPeek : IDisposable
 
     public void SetPeekOnTaskbarClick(bool enabled)
     {
-        DesktopDetector.PeekOnTaskbarClick = enabled;
+        _mouseHook.MonitorTaskbarClicks = enabled;
         AppDiagnostics.Log($"PeekOnTaskbarClick set to {enabled}");
     }
 
     public void SetPeekOnDesktopClick(bool enabled)
     {
         _peekOnDesktopClick = enabled;
+        _mouseHook.MonitorDesktopClicks = enabled;
         AppDiagnostics.Log($"PeekOnDesktopClick set to {enabled}");
     }
 
@@ -219,36 +223,6 @@ public sealed class DesktopPeek : IDisposable
         }
 
         AppDiagnostics.Log("Desktop icon clicked; not entering peek mode");
-    }
-
-    private void OnNonDesktopClicked(object? sender, EventArgs e)
-    {
-        if (!_isPeeking || _isTransitioning)
-        {
-            AppDiagnostics.Log($"Non-desktop click ignored. IsPeeking={_isPeeking} Transitioning={_isTransitioning}");
-            return;
-        }
-
-        if (Environment.TickCount64 < _ignoreRestoreClickUntil)
-        {
-            AppDiagnostics.Log("Non-desktop click ignored because it immediately followed activation");
-            return;
-        }
-
-        if (_nativeShellToggled)
-        {
-            AppDiagnostics.Log("Non-desktop click while native show desktop is active; deferring restore to shell");
-            return;
-        }
-
-        if (!_restoreHiddenWindowsOnAppOpen)
-        {
-            AppDiagnostics.Log("Non-desktop click detected while peeking; staying in peek mode because restore-on-app-switch is disabled");
-            return;
-        }
-
-        AppDiagnostics.Log("Non-desktop click detected while peeking; restoring windows");
-        RestoreWindows();
     }
 
     private void OnFocusChanged(object? sender, FocusChangedEventArgs e)

--- a/src/PeekDesktop/MouseHook.cs
+++ b/src/PeekDesktop/MouseHook.cs
@@ -1,9 +1,93 @@
 using System;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace PeekDesktop;
+
+internal readonly record struct PendingMouseClick(IntPtr Window, NativeMethods.POINT Point);
+
+internal sealed class MouseClickTracker
+{
+    private bool _hasPreviousClick;
+    private long _previousClickTick;
+    private IntPtr _previousClickWindow;
+    private NativeMethods.POINT _previousClickPoint;
+    private bool _hasPendingClick;
+    private PendingMouseClick _pendingClick;
+
+    internal bool HasPendingClick => _hasPendingClick;
+
+    internal bool TryBeginClick(
+        IntPtr window,
+        NativeMethods.POINT point,
+        bool requireDoubleClick,
+        long tick,
+        uint doubleClickTime,
+        int cxDoubleClick,
+        int cyDoubleClick)
+    {
+        if (requireDoubleClick)
+        {
+            bool isDoubleClick = _hasPreviousClick
+                && window == _previousClickWindow
+                && (tick - _previousClickTick) <= doubleClickTime
+                && Math.Abs(point.x - _previousClickPoint.x) <= cxDoubleClick
+                && Math.Abs(point.y - _previousClickPoint.y) <= cyDoubleClick;
+
+            if (!isDoubleClick)
+            {
+                _hasPreviousClick = true;
+                _previousClickTick = tick;
+                _previousClickWindow = window;
+                _previousClickPoint = point;
+                _hasPendingClick = false;
+                return false;
+            }
+
+            _hasPreviousClick = false;
+        }
+        else
+        {
+            _hasPreviousClick = false;
+        }
+
+        _pendingClick = new PendingMouseClick(window, point);
+        _hasPendingClick = true;
+        return true;
+    }
+
+    internal bool CancelIfMoved(NativeMethods.POINT point, int cxDrag, int cyDrag)
+    {
+        if (!_hasPendingClick
+            || (Math.Abs(point.x - _pendingClick.Point.x) <= cxDrag
+                && Math.Abs(point.y - _pendingClick.Point.y) <= cyDrag))
+        {
+            return false;
+        }
+
+        _hasPendingClick = false;
+        return true;
+    }
+
+    internal bool TryCompleteClick(
+        NativeMethods.POINT point,
+        int cxDrag,
+        int cyDrag,
+        out PendingMouseClick click)
+    {
+        click = _pendingClick;
+        if (!_hasPendingClick)
+            return false;
+
+        _hasPendingClick = false;
+        return Math.Abs(point.x - click.Point.x) <= cxDrag
+            && Math.Abs(point.y - click.Point.y) <= cyDrag;
+    }
+
+    internal void Reset()
+    {
+        _hasPreviousClick = false;
+        _hasPendingClick = false;
+    }
+}
 
 /// <summary>
 /// Installs a low-level mouse hook (WH_MOUSE_LL) and raises an event
@@ -12,26 +96,57 @@ namespace PeekDesktop;
 /// </summary>
 public sealed class MouseHook : IDisposable
 {
+    private readonly Action<Action> _beginInvoke;
+    private readonly MouseClickTracker _clickTracker = new();
     private IntPtr _hookId = IntPtr.Zero;
 
     // Must be stored as a field to prevent GC collection while the hook is active.
     private NativeMethods.LowLevelMouseProc? _hookProc;
-    private SynchronizationContext? _syncContext;
-
-    // Double-click detection state (low-level hooks never see WM_LBUTTONDBLCLK)
-    private long _lastClickTick;
-    private NativeMethods.POINT _lastClickPoint;
-
-    // Pending-click state: we defer firing the classification event until WM_LBUTTONUP
-    // so we can suppress the peek when the user is actually drag-selecting icons
-    // on the desktop (e.g. marquee multi-select). See issue #35.
-    private bool _hasPendingClick;
-    private NativeMethods.POINT _pendingDownPoint;
+    private bool _requireDoubleClick;
+    private bool _monitorDesktopClicks;
+    private bool _monitorTaskbarClicks;
 
     /// <summary>
     /// When true, only double-clicks trigger desktop peek (single clicks are ignored).
     /// </summary>
-    public bool RequireDoubleClick { get; set; }
+    public bool RequireDoubleClick
+    {
+        get => _requireDoubleClick;
+        set
+        {
+            if (_requireDoubleClick == value)
+                return;
+
+            _requireDoubleClick = value;
+            _clickTracker.Reset();
+        }
+    }
+
+    internal bool MonitorDesktopClicks
+    {
+        get => _monitorDesktopClicks;
+        set
+        {
+            if (_monitorDesktopClicks == value)
+                return;
+
+            _monitorDesktopClicks = value;
+            _clickTracker.Reset();
+        }
+    }
+
+    internal bool MonitorTaskbarClicks
+    {
+        get => _monitorTaskbarClicks;
+        set
+        {
+            if (_monitorTaskbarClicks == value)
+                return;
+
+            _monitorTaskbarClicks = value;
+            _clickTracker.Reset();
+        }
+    }
 
     /// <summary>
     /// Raised (on the UI thread) when a left-click on empty desktop wallpaper is detected.
@@ -44,21 +159,21 @@ public sealed class MouseHook : IDisposable
     public event EventHandler? DesktopIconClicked;
 
     /// <summary>
-    /// Raised (on the UI thread) when a left-click lands on something other than the desktop.
-    /// </summary>
-    public event EventHandler? NonDesktopClicked;
-
-    /// <summary>
     /// Raised (on the UI thread) when a left-click lands on empty taskbar space.
     /// </summary>
     public event EventHandler? TaskbarClicked;
+
+    public MouseHook(Action<Action> beginInvoke)
+    {
+        ArgumentNullException.ThrowIfNull(beginInvoke);
+        _beginInvoke = beginInvoke;
+    }
 
     public void Install()
     {
         if (_hookId != IntPtr.Zero)
             return;
 
-        _syncContext = SynchronizationContext.Current;
         _hookProc = HookCallback;
         _hookId = NativeMethods.SetWindowsHookEx(
             NativeMethods.WH_MOUSE_LL,
@@ -75,13 +190,14 @@ public sealed class MouseHook : IDisposable
             NativeMethods.UnhookWindowsHookEx(_hookId);
             AppDiagnostics.Log($"Mouse hook uninstalled: 0x{_hookId.ToInt64():X}");
             _hookId = IntPtr.Zero;
+            _clickTracker.Reset();
         }
     }
 
     /// <summary>
-    /// Hook callback — must return FAST to avoid Windows unhooking us.
-    /// It captures the click point and posts the heavier classification
-    /// work to the UI thread.
+    /// Hook callback - must return fast to avoid Windows unhooking us.
+    /// It only tracks clicks on configured Explorer surfaces and posts
+    /// heavier classification work to the application's message loop.
     /// </summary>
     private unsafe IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
     {
@@ -92,75 +208,53 @@ public sealed class MouseHook : IDisposable
             if (message == NativeMethods.WM_LBUTTONDOWN)
             {
                 var hookStruct = *(NativeMethods.MSLLHOOKSTRUCT*)lParam;
-                var clickPoint = hookStruct.pt;
+                NativeMethods.POINT clickPoint = hookStruct.pt;
+                IntPtr windowUnderCursor = NativeMethods.WindowFromPoint(clickPoint);
 
-                if (RequireDoubleClick)
+                if (!DesktopDetector.IsPotentialPeekSurfaceWindow(
+                    windowUnderCursor,
+                    clickPoint,
+                    MonitorDesktopClicks,
+                    MonitorTaskbarClicks))
                 {
-                    long now = Environment.TickCount64;
-                    uint doubleClickTime = NativeMethods.GetDoubleClickTime();
-                    int cxThreshold = NativeMethods.GetSystemMetrics(NativeMethods.SM_CXDOUBLECLK) / 2;
-                    int cyThreshold = NativeMethods.GetSystemMetrics(NativeMethods.SM_CYDOUBLECLK) / 2;
-
-                    bool withinTime = (now - _lastClickTick) <= doubleClickTime;
-                    bool withinDistance = Math.Abs(clickPoint.x - _lastClickPoint.x) <= cxThreshold
-                                      && Math.Abs(clickPoint.y - _lastClickPoint.y) <= cyThreshold;
-
-                    _lastClickTick = now;
-                    _lastClickPoint = clickPoint;
-
-                    if (!(withinTime && withinDistance))
-                    {
-                        // First click of a potential double-click — don't arm the pending trigger yet
-                        _hasPendingClick = false;
-                        return NativeMethods.CallNextHookEx(_hookId, nCode, wParam, lParam);
-                    }
-
-                    // Reset so a third click doesn't also fire
-                    _lastClickTick = 0;
+                    _clickTracker.Reset();
+                    return NativeMethods.CallNextHookEx(_hookId, nCode, wParam, lParam);
                 }
 
-                // Arm a pending click; the actual classification + event will fire
-                // on WM_LBUTTONUP, unless the user drags beyond the drag threshold
-                // (which indicates a marquee / drag-select gesture).
-                _hasPendingClick = true;
-                _pendingDownPoint = clickPoint;
+                _clickTracker.TryBeginClick(
+                    windowUnderCursor,
+                    clickPoint,
+                    RequireDoubleClick,
+                    Environment.TickCount64,
+                    NativeMethods.GetDoubleClickTime(),
+                    NativeMethods.GetSystemMetrics(NativeMethods.SM_CXDOUBLECLK) / 2,
+                    NativeMethods.GetSystemMetrics(NativeMethods.SM_CYDOUBLECLK) / 2);
             }
-            else if (message == NativeMethods.WM_MOUSEMOVE)
+            else if (message == NativeMethods.WM_MOUSEMOVE && _clickTracker.HasPendingClick)
             {
-                if (_hasPendingClick)
+                var hookStruct = *(NativeMethods.MSLLHOOKSTRUCT*)lParam;
+                if (_clickTracker.CancelIfMoved(
+                    hookStruct.pt,
+                    NativeMethods.GetSystemMetrics(NativeMethods.SM_CXDRAG),
+                    NativeMethods.GetSystemMetrics(NativeMethods.SM_CYDRAG)))
                 {
-                    var hookStruct = *(NativeMethods.MSLLHOOKSTRUCT*)lParam;
-                    if (HasExceededDragThreshold(_pendingDownPoint, hookStruct.pt))
-                    {
-                        _hasPendingClick = false;
-                        AppDiagnostics.Log("Pending peek click cancelled (drag detected)");
-                    }
+                    AppDiagnostics.Log("Pending peek click cancelled (drag detected)");
                 }
             }
-            else if (message == NativeMethods.WM_LBUTTONUP)
+            else if (message == NativeMethods.WM_LBUTTONUP && _clickTracker.HasPendingClick)
             {
-                if (_hasPendingClick)
+                var hookStruct = *(NativeMethods.MSLLHOOKSTRUCT*)lParam;
+                if (!_clickTracker.TryCompleteClick(
+                    hookStruct.pt,
+                    NativeMethods.GetSystemMetrics(NativeMethods.SM_CXDRAG),
+                    NativeMethods.GetSystemMetrics(NativeMethods.SM_CYDRAG),
+                    out PendingMouseClick click))
                 {
-                    _hasPendingClick = false;
-                    var hookStruct = *(NativeMethods.MSLLHOOKSTRUCT*)lParam;
-                    var upPoint = hookStruct.pt;
-
-                    if (HasExceededDragThreshold(_pendingDownPoint, upPoint))
-                    {
-                        AppDiagnostics.Log("Pending peek click cancelled on mouse-up (drag detected)");
-                    }
-                    else
-                    {
-                        // Classify based on the original press location so a tiny
-                        // cursor jitter during the click doesn't change the target.
-                        var classifyPoint = _pendingDownPoint;
-                        IntPtr windowUnderCursor = NativeMethods.WindowFromPoint(classifyPoint);
-
-                        if (_syncContext is not null)
-                            _syncContext.Post(_ => HandleMouseClick(windowUnderCursor, classifyPoint), null);
-                        else
-                            HandleMouseClick(windowUnderCursor, classifyPoint);
-                    }
+                    AppDiagnostics.Log("Pending peek click cancelled on mouse-up (drag detected)");
+                }
+                else
+                {
+                    DispatchMouseClick(click.Window, click.Point);
                 }
             }
         }
@@ -168,12 +262,9 @@ public sealed class MouseHook : IDisposable
         return NativeMethods.CallNextHookEx(_hookId, nCode, wParam, lParam);
     }
 
-    private static bool HasExceededDragThreshold(NativeMethods.POINT from, NativeMethods.POINT to)
+    internal void DispatchMouseClick(IntPtr windowUnderCursor, NativeMethods.POINT clickPoint)
     {
-        int cxDrag = NativeMethods.GetSystemMetrics(NativeMethods.SM_CXDRAG);
-        int cyDrag = NativeMethods.GetSystemMetrics(NativeMethods.SM_CYDRAG);
-        return Math.Abs(to.x - from.x) > cxDrag
-            || Math.Abs(to.y - from.y) > cyDrag;
+        _beginInvoke(() => HandleMouseClick(windowUnderCursor, clickPoint));
     }
 
     private void HandleMouseClick(IntPtr windowUnderCursor, NativeMethods.POINT clickPoint)
@@ -185,7 +276,11 @@ public sealed class MouseHook : IDisposable
         AppDiagnostics.Log($"Mouse click point: {NativeMethods.DescribePoint(clickPoint)}");
         AppDiagnostics.Log($"Mouse click target: {NativeMethods.DescribeWindow(windowUnderCursor)}");
         AppDiagnostics.Log($"Mouse click hierarchy: {NativeMethods.DescribeWindowHierarchy(windowUnderCursor)}");
-        DesktopClickTarget clickTarget = DesktopDetector.GetClickTarget(windowUnderCursor, clickPoint);
+        DesktopClickTarget clickTarget = DesktopDetector.GetClickTarget(
+            windowUnderCursor,
+            clickPoint,
+            MonitorDesktopClicks,
+            MonitorTaskbarClicks);
         AppDiagnostics.Log($"Mouse click classification: {clickTarget}");
 
         switch (clickTarget)
@@ -200,10 +295,6 @@ public sealed class MouseHook : IDisposable
 
             case DesktopClickTarget.TaskbarBackground:
                 TaskbarClicked?.Invoke(this, EventArgs.Empty);
-                break;
-
-            default:
-                NonDesktopClicked?.Invoke(this, EventArgs.Empty);
                 break;
         }
     }

--- a/src/PeekDesktop/Program.cs
+++ b/src/PeekDesktop/Program.cs
@@ -56,7 +56,7 @@ public static class Program
             AppDiagnostics.Log("Message loop created");
 
             // Defer initialization until the message loop is pumping so hooks
-            // and SynchronizationContext-like callbacks work correctly.
+            // and posted callbacks work correctly.
             messageLoop.PostDeferredAction(1, () =>
             {
                 try
@@ -96,7 +96,7 @@ public static class Program
     {
         var settings = Settings.Load();
         Settings.SetAutoStart(settings.StartWithWindows);
-        _desktopPeek = new DesktopPeek(settings);
+        _desktopPeek = new DesktopPeek(settings, messageLoop.BeginInvoke);
         _desktopPeek.SetRestoreHiddenWindowsOnAppOpen(settings.RestoreHiddenWindowsOnAppOpen);
         _appUpdater = new AppUpdater(messageLoop);
 


### PR DESCRIPTION
## Summary
- gate low-level mouse tracking to enabled Explorer desktop/taskbar surfaces
- dispatch detailed classification through the native message loop instead of inside `WH_MOUSE_LL`
- remove non-desktop mouse notifications and use foreground activation for restoration
- add regression coverage for click sequencing, surface boundaries, drag cancellation, and deferred dispatch

## Validation
- `test.ps1`
- NativeAOT x64 publish
- local manual double-click verification with PeekDesktop active

Fixes #71

Thanks @elimwang for the clear report that led us to the v0.6.0 synchronization regression.